### PR TITLE
config: add apm env to config if available

### DIFF
--- a/extra/run-dogstatsd.sh
+++ b/extra/run-dogstatsd.sh
@@ -23,6 +23,10 @@ if [[ $DD_TAGS ]]; then
   sed -i -r -e "s/^# ?tags:.*$/tags: ${DD_TAGS}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
 fi
 
+if [[ $DD_APP_ENV ]]; then
+  printf "\n[trace.config]\nenv=${DD_APP_ENV}" >> /app/.apt/opt/datadog-agent/agent/datadog.conf
+fi
+
 mkdir -p /tmp/logs/datadog
 
 (


### PR DESCRIPTION
This allows us to pin an app to an environment absent the infra agent