### PR TITLE
Move -c option behind on execution of the agent command

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -57,5 +57,5 @@ if [ -n "$DISABLE_DATADOG_AGENT" ]; then
 else
   # Run the Datadog Agent
   echo "Starting Datadog Agent on dyno $DYNO"
-  bash -c "PYTHONPATH=$DD_DIR/embedded/lib/python2.7 $DD_BIN_DIR/agent -c $DATADOG_CONF start 2>&1 &"
+  bash -c "PYTHONPATH=$DD_DIR/embedded/lib/python2.7 $DD_BIN_DIR/agent start -c $DATADOG_CONF 2>&1 &"
 fi


### PR DESCRIPTION
This change made it possible to start the agent on a dyno with datadog-agent-6.0.0~rc.1-1_amd64 regarding #28