### PR TITLE
Install only the latest .deb file for each package

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -38,7 +38,7 @@ apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommen
 IFS=" " read -a DEP_PKGS <<< $DEPS
 for DEP in ${DEP_PKGS[@]}; do
   echo "Installing $DEP" | indent
-  dpkg -x $APT_CACHE_DIR/archives/$DEP\_*.deb $APT_DIR
+  ls -t $APT_CACHE_DIR/archives/$DEP\_*.deb | head -1 | xargs -i dpkg -x '{}' $APT_DIR
 done
 
 # Install Datadog Agent


### PR DESCRIPTION
When there are more than one .deb files like
- `/app/tmp/cache/apt/cache/archives/libsnmp-base_5.7.3+dfsg-1ubuntu4.1_all.deb`
- `/app/tmp/cache/apt/cache/archives/libsnmp-base_5.7.3+dfsg-1ubuntu4_all.deb`
the line `dpkg -x $APT_CACHE_DIR/archives/$DEP\_*.deb $APT_DIR` fails:

```
dpkg-deb: error: --extract takes at most two arguments (.deb and directory)
```