### PR TITLE
RFC1123 doesn't allow underscores in hostnames

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -57,10 +57,10 @@ fi
 if [ -z "$DD_HOSTNAME" ]; then
   if [ "$DD_DYNO_HOST" == "true" ]; then
     # Set the hostname to dyno name
-    export DD_HOSTNAME="$HEROKU_APP_NAME.$DYNO"
+    export DD_HOSTNAME="${HEROKU_APP_NAME//_/-}.${DYNO//_/-}"
   else
     # Set the hostname to the dyno host
-    export DD_HOSTNAME=$DYNOHOST
+    export DD_HOSTNAME="${DYNOHOST//_/-}"
   fi
 else
   # Generate a warning about DD_HOSTNAME deprecation.

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -58,11 +58,11 @@ if [ -z "$DD_HOSTNAME" ]; then
   if [ "$DD_DYNO_HOST" == "true" ]; then
     # Set the hostname to dyno name and ensure rfc1123 compliance.
     HAN=$( echo $HEROKU_APP_NAME | sed -e 's/[^a-zA-Z0-9-]/-/g' -e 's/^-//g' )
-    if [ "$HAN" != "$D" ]; then
+    if [ "$HAN" != "$HEROKU_APP_NAME" ]; then
       echo "WARNING: The appname \"$HEROKU_APP_NAME\" contains invalid characters. Using \"$HAN\" instead."
     fi
 
-    D=$( echo $DYNO | sed -e 's/[^a-zA-Z0-9-]/-/g' -e 's/^-//g' )
+    D=$( echo $DYNO | sed -e 's/[^a-zA-Z0-9.-]/-/g' -e 's/^-//g' )
     export DD_HOSTNAME="$HAN.$D"
   else
     # Set the hostname to the dyno host

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -56,11 +56,17 @@ fi
 
 if [ -z "$DD_HOSTNAME" ]; then
   if [ "$DD_DYNO_HOST" == "true" ]; then
-    # Set the hostname to dyno name
-    export DD_HOSTNAME="${HEROKU_APP_NAME//_/-}.${DYNO//_/-}"
+    # Set the hostname to dyno name and ensure rfc1123 compliance.
+    HAN=$( echo $HEROKU_APP_NAME | sed -e 's/[^a-zA-Z0-9-]/-/g' -e 's/^-//g' )
+    if [ "$HAN" != "$D" ]; then
+      echo "WARNING: The appname \"$HEROKU_APP_NAME\" contains invalid characters. Using \"$HAN\" instead."
+    fi
+
+    D=$( echo $DYNO | sed -e 's/[^a-zA-Z0-9-]/-/g' -e 's/^-//g' )
+    export DD_HOSTNAME="$HAN.$D"
   else
     # Set the hostname to the dyno host
-    export DD_HOSTNAME="${DYNOHOST//_/-}"
+    export DD_HOSTNAME=$( echo $DYNOHOST | sed -e 's/[^a-zA-Z0-9-]/-/g' -e 's/^-//g' )
   fi
 else
   # Generate a warning about DD_HOSTNAME deprecation.


### PR DESCRIPTION
We probably want to be more robust about catching errors of this nature, but this change will fix the immediate issue customers were having with underscores in DYNO names (which seems to be fairly common pattern).