### PR TITLE
Set pipefail so apt errors aren't obscured by the pipe to indent.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -3,6 +3,7 @@
 
 # Fail fast
 set -e
+set -o pipefail
 
 # Debug
 # set -x


### PR DESCRIPTION
```
If pipefail is enabled, the pipeline’s return status is the value of the last (rightmost) command to exit with a non-zero status, or zero if all commands exit successfully.
```

So this allows `apt-get … | indent` to fail if apt-get returns a non-zero status. Otherwise the script progresses and makes tracking down errors hard.