### PR TITLE
Updates `PYTHONPATH` to include integrations

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -17,7 +17,6 @@ export PKG_CONFIG_PATH="$APT_DIR/usr/lib/x86_64-linux-gnu/pkgconfig:$APT_DIR/usr
 
 # Set Datadog configs
 export DD_LOG_FILE="$DD_LOG_DIR/datadog.log"
-export DD_CONF_PATH="$DD_CONF_DIR"
 
 # Move Datadog config files into place
 cp $DATADOG_CONF.example $DATADOG_CONF
@@ -76,15 +75,25 @@ fi
 if [ -n "$DISABLE_DATADOG_AGENT" ]; then
   echo "The Datadog Agent has been disabled. Unset the DISABLE_DATADOG_AGENT or set missing environment variables."
 else
+  # Setup Python Path
+  DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7"
+  for python_mod_dir in $(ls -d $DD_DIR/embedded/lib/python*/site-packages 2>/dev/null); do
+    DD_PYTHONPATH="${python_mod_dir}:${DD_PYTHONPATH}"
+  done
+  DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/plat-linux2:$DD_PYTHONPATH"
+  DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/lib-tk:$DD_PYTHONPATH"
+  DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/lib-dynload:$DD_PYTHONPATH"
+  DD_PYTHONPATH="$DD_DIR/bin/agent/dist:$DD_PYTHONPATH"
+
   # Run the Datadog Agent
-  echo "Starting Datadog Agent on dyno $DYNO"
-  bash -c "PYTHONPATH=$DD_DIR/embedded/lib/python2.7 $DD_BIN_DIR/agent start -c $DATADOG_CONF 2>&1 &"
+  echo "Starting Datadog Agent on $DD_HOSTNAME"
+  bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" $DD_BIN_DIR/agent start -c $DATADOG_CONF 2>&1 &"
 
   # The Trace Agent will run by default.
   if [ "$DD_APM_ENABLED" == "false" ]; then
     echo "The Datadog Trace Agent has been disabled. Set DD_APM_ENABLED to true or unset it."
   else
-    echo "Starting Datadog Trace Agent on dyno $DYNO"
+    echo "Starting Datadog Trace Agent on $DD_HOSTNAME"
     bash -c "$DD_DIR/embedded/bin/trace-agent -config $DATADOG_CONF 2>&1 &"
   fi
 fi


### PR DESCRIPTION
Some core checks could not load python libs due to a truncated PYTHONPATH. This builds out a fuller PYTHONPATH.