### PR TITLE
Support custom configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ In addition to the environment variables shown above, there are a number of othe
 
 For additional documentation, refer to the [Datadog Heroku buildpack documentation](https://docs.datadoghq.com/agent/basic_agent_usage/heroku/) and the [Datadog Agent documentation](https://docs.datadoghq.com/agent/).
 
+You can also provide additional configurations by including `*.yaml` files inside `datadog/conf.d` directory in root of your application.
+
 ## Hostname
 
 Heroku dynos are ephemeral—they can move to different host machines whenever new code is deployed, configuration changes are made, or resouce needs/availability changes. This makes Heroku flexible and responsive, but can potentially lead to a high number of reported hosts in Datadog. Datadog bills on a per-host basis, and the buildpack default is to report actual hosts, which can lead to higher than expected costs.

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -26,6 +26,16 @@ cp $DATADOG_CONF.example $DATADOG_CONF
 sed -i -e"s|^.*confd_path:.*$|confd_path: $DD_CONF_DIR/conf.d|" $DATADOG_CONF
 sed -i -e"s|^.*additional_checksd:.*$|additional_checksd: $DD_DIR/checks.d|" $DATADOG_CONF
 
+# Include application's datadog configs
+APP_DATADOG_CONF_DIR="/app/datadog/conf.d"
+
+for file in "$APP_DATADOG_CONF_DIR"/*.yaml; do
+  filename=$(basename -- "$file")
+  filename="${filename%.*}"
+  mkdir -p "$DD_CONF_DIR/conf.d/${filename}.d"
+  cp $file "$DD_CONF_DIR/conf.d/${filename}.d/conf.yaml"
+done
+
 # Add tags to the config file
 DYNOHOST="$( hostname )"
 DYNOTYPE=${DYNO%%.*}
@@ -75,6 +85,7 @@ else
   # Generate a warning about DD_HOSTNAME deprecation.
   echo "WARNING: DD_HOSTNAME is deprecated. Setting this environment variable may result in metrics errors. To remove it, run: heroku config:unset DD_HOSTNAME"
 fi
+
 
 if [ -n "$DISABLE_DATADOG_AGENT" ]; then
   echo "The Datadog Agent has been disabled. Unset the DISABLE_DATADOG_AGENT or set missing environment variables."


### PR DESCRIPTION
This simple change allows to provide additional DataDog configuration in the `datadog` folder in root of the application.

For testing on Heroku we can use this buildpack using `https://github.com/DataDog/heroku-buildpack-datadog.git#custom-datadog` URL.