### PR TITLE
Improve version handling

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -62,7 +62,7 @@ apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommen
 DPKG_STUB="$APT_CACHE_DIR/archives/datadog-agent_1%3a"
 if [ -f $ENV_DIR/DD_AGENT_VERSION ]; then
   DD_AGENT_VERSION=$(cat $ENV_DIR/DD_AGENT_VERSION)
-  DEB="$DPKG_STUB$DD_AGENT_VERSION.deb"
+  DEB="$DPKG_STUB$DD_AGENT_VERSION-1_amd64.deb"
   if [ -e $DEB ]; then
     echo "Installing pinned version \"$DD_AGENT_VERSION\"" | indent
   # Stop if we can't find the version.

--- a/bin/compile
+++ b/bin/compile
@@ -67,6 +67,8 @@ if [ -f $ENV_DIR/DD_AGENT_VERSION ]; then
   # Stop if we can't find the version.
   if [ -z "$DEB" ]; then
     topic "ERROR: Version \"$DD_AGENT_VERSION\" was not found."
+    echo "Available versions:" | indent
+    ls -t $DPKG_STUB*.deb | indent
     exit 1
   fi
 else

--- a/bin/compile
+++ b/bin/compile
@@ -62,10 +62,11 @@ apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommen
 DPKG_STUB="$APT_CACHE_DIR/archives/datadog-agent_1%3a"
 if [ -f $ENV_DIR/DD_AGENT_VERSION ]; then
   DD_AGENT_VERSION=$(cat $ENV_DIR/DD_AGENT_VERSION)
-  echo "Installing pinned version \"$DD_AGENT_VERSION\"" | indent
-  DEB=$(ls -t $DPKG_STUB$DD_AGENT_VERSION.deb | head -n 1)
+  DEB="$DPKG_STUB$DD_AGENT_VERSION.deb"
+  if [ -e $DEB ]; then
+    echo "Installing pinned version \"$DD_AGENT_VERSION\"" | indent
   # Stop if we can't find the version.
-  if [ -z "$DEB" ]; then
+  else
     topic "ERROR: Version \"$DD_AGENT_VERSION\" was not found."
     echo "Available versions:" | indent
     ls -t $DPKG_STUB*.deb | indent

--- a/bin/compile
+++ b/bin/compile
@@ -62,14 +62,16 @@ apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommen
 DPKG_STUB="$APT_CACHE_DIR/archives/datadog-agent_1%3a"
 if [ -f $ENV_DIR/DD_AGENT_VERSION ]; then
   DD_AGENT_VERSION=$(cat $ENV_DIR/DD_AGENT_VERSION)
-  DEB="$DPKG_STUB$DD_AGENT_VERSION-1_amd64.deb"
+  DEB="$DPKG_STUB$DD_AGENT_VERSION.deb"
   if [ -e $DEB ]; then
     echo "Installing pinned version \"$DD_AGENT_VERSION\"" | indent
   # Stop if we can't find the version.
   else
     topic "ERROR: Version \"$DD_AGENT_VERSION\" was not found."
     echo "Available versions:" | indent
-    ls -t $DPKG_STUB*.deb | indent
+    for PKG in $DPKG_STUB*.deb; do
+      echo ${PKG:${#DPKG_STUB}:(${#PKG}-${#DPKG_STUB}-4)} | indent
+    done
     exit 1
   fi
 else

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -105,7 +105,7 @@ else
   DD_VERSION=`expr "$($DD_BIN_DIR/agent version)" : 'Agent \([0-9]\+\.[0-9]\+.[0-9]\+\)'`
 
   # Prior to Agent 2.4.1, the command is "start"
-  RUN_VERSION="2.4.1"
+  RUN_VERSION="6.4.1"
   if [ "$DD_VERSION" == "`echo -e "$RUN_VERSION\n$DD_VERSION" | sort -V | head -n1`" ]; then
     RUN_COMMAND="start"
   else

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -101,9 +101,20 @@ else
   DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/lib-dynload:$DD_PYTHONPATH"
   DD_PYTHONPATH="$DD_DIR/bin/agent/dist:$DD_PYTHONPATH"
 
+  # Get the Agent version number
+  DD_VERSION=`expr "$($DD_BIN_DIR/agent version)" : 'Agent \([0-9]\+\.[0-9]\+.[0-9]\+\)'`
+
+  # Prior to Agent 2.4.1, the command is "start"
+  RUN_VERSION="2.4.1"
+  if [ "$DD_VERSION" == "`echo -e "$RUN_VERSION\n$DD_VERSION" | sort -V | head -n1`" ]; then
+    RUN_COMMAND="start"
+  else
+    RUN_COMMAND="run"
+  fi
+
   # Run the Datadog Agent
   echo "Starting Datadog Agent on $DD_HOSTNAME"
-  bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" $DD_BIN_DIR/agent start -c $DATADOG_CONF 2>&1 &"
+  bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" $DD_BIN_DIR/agent $RUN_COMMAND -c $DATADOG_CONF 2>&1 &"
 
   # The Trace Agent will run by default.
   if [ "$DD_APM_ENABLED" == "false" ]; then


### PR DESCRIPTION
This addresses the `run` vs `start` deprecation issue mentioned in #55, but maintains backward compatibility for older pinned versions of the agent. I've also corrected the error handling for when an invalid version is pinned and the new error message will generate a list of available versions.