### PR TITLE
add datadog repo as trusted

### DIFF
--- a/etc/datadog.list
+++ b/etc/datadog.list
@@ -1,3 +1,3 @@
 # We're using insecure http here. Eventually we should fix
 # the apt-transport-https issue.
-deb http://apt.datadoghq.com/ stable 6
+deb [trusted=yes] http://apt.datadoghq.com/ stable 6


### PR DESCRIPTION
Modifies the apt source to be trusted so gpg errors can be ignored.

To use this, update your heroku buildpacks:
```
heroku buildpacks:remove https://github.com/DataDog/heroku-buildpack-datadog.git
heroku buildpacks:add --index 1 https://github.com/DataDog/heroku-buildpack-datadog.git#jyee/gpg_key
```

In the long run, we should find a way to properly validate the gpg signature to ensure that heroku apps are getting authenticated Datadog Agent installs, but this will keep your Heroku-18 stack applications running in the meantime.