### PR TITLE
Add DD_APM_TRACE_SEARCH option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ In addition to the environment variables shown above, there are a number of othe
 | `DD_HISTOGRAM_PERCENTILES` | *Optional.* Optionally set additional percentiles for your histogram metrics. See the [Histogram percentiles article](https://help.datadoghq.com/hc/en-us/articles/204588979-How-to-graph-percentiles-in-Datadog) for more information. |
 | `DISABLE_DATADOG_AGENT` | *Optional.* When set, the Datadog Agent will not be run. |
 | `DD_APM_ENABLED` | *Optional.* The Datadog Trace Agent (APM) is run by default. Set this to `false` to disable the Trace Agent. |
+| `DD_APM_TRACE_SEARCH` | *Optional.* Enables configuration for [APM Trace Search & Analytics](https://www.datadoghq.com/blog/trace-search-high-cardinality-data/). Disabled by default. |
+| `DD_APM_SERVICE_NAME` | *Optional.* If `DD_APM_TRACE_SEARCH` is enabled, this value must be set to the name of your service in Datadog APM. |
 | `DD_AGENT_VERSION` | *Optional.* By default, the buildpack installs the latest version of the Datadog Agent available in the package repository. Use this variable to install older versions of the Datadog Agent (note that not all versions of the Agent may be available). |
 | `DD_SERVICE_ENV` | *Optional.* The Datadog Agent automatically tries to identify your environment by searching for a tag in the form `env:<environment name>`. For more information, see the [Datadog Tracing environments page](https://docs.datadoghq.com/tracing/environments/). |
 

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -57,9 +57,6 @@ fi
 # Inject tags after example tags.
 sed -i "s/^#   - role:database$/#   - role:database\n$TAGS/" $DATADOG_CONF
 
-# Uncomment APM configs and add the log file location.
-sed -i -e"s|^# apm_config:$|apm_config:\n    log_file: $DD_APM_LOG|" $DATADOG_CONF
-
 # For a list of env vars to override datadog.yaml, see:
 # https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config.go#L145
 
@@ -87,6 +84,12 @@ else
   echo "WARNING: DD_HOSTNAME is deprecated. Setting this environment variable may result in metrics errors. To remove it, run: heroku config:unset DD_HOSTNAME"
 fi
 
+# Uncomment APM configs and add the log file location.
+if [ -n "$DD_APM_TRACE_SEARCH" ]; then
+  sed -i -e"s|^# apm_config:$|apm_config:\n    analyzed_spans:\n        $DD_APM_SERVICE_NAME\|http.request: 1\n    log_file: $DD_APM_LOG|" $DATADOG_CONF
+else
+  sed -i -e"s|^# apm_config:$|apm_config:\n    log_file: $DD_APM_LOG|" $DATADOG_CONF
+fi
 
 if [ -n "$DISABLE_DATADOG_AGENT" ]; then
   echo "The Datadog Agent has been disabled. Unset the DISABLE_DATADOG_AGENT or set missing environment variables."


### PR DESCRIPTION
Closes #64 

Please note: I'm not sure if this is the correct approach to this problem. If it isn't, please let me know what is.

This change adds `DD_APM_TRACE_SEARCH` and `DD_APM_SERVICE_NAME` as an environment variable option. When `DD_APM_TRACE_SEARCH` is set to true, it alters the `apm_config` to result in output like:

```
apm_config:
  analyzed_spans:
    DD_APM_SERVICE_NAME|http.request: 1
log_file: ...
```

This change should allow users to enable APM Trace Search & Analytics in DataDog.