### PR TITLE
Add logic to autoconfig postgress check

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ In addition to the environment variables shown above, there are a number of othe
 | `DD_PROCESS_AGENT` | *Optional.* The Datadog Process Agent is disabled by default. Set this to `true` to enable the Process Agent. |
 | `DD_AGENT_VERSION` | *Optional.* By default, the buildpack installs the latest version of the Datadog Agent available in the package repository. Use this variable to install older versions of the Datadog Agent (note that not all versions of the Agent may be available). |
 | `DD_SERVICE_ENV` | *Optional.* The Datadog Agent automatically tries to identify your environment by searching for a tag in the form `env:<environment name>`. For more information, see the [Datadog Tracing environments page](https://docs.datadoghq.com/tracing/environments/). |
+| `HEROKU_POSTGRES` | *Optional.* When set to `true` the Datadog Postgres check will be auto-configured from the DATABASE_URL environment variable. |
 
 For additional documentation, refer to the [Datadog Agent documentation](https://docs.datadoghq.com/agent/).
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In addition to the environment variables shown above, there are a number of othe
 | `DD_PROCESS_AGENT` | *Optional.* The Datadog Process Agent is disabled by default. Set this to `true` to enable the Process Agent. |
 | `DD_AGENT_VERSION` | *Optional.* By default, the buildpack installs the latest version of the Datadog Agent available in the package repository. Use this variable to install older versions of the Datadog Agent (note that not all versions of the Agent may be available). |
 | `DD_SERVICE_ENV` | *Optional.* The Datadog Agent automatically tries to identify your environment by searching for a tag in the form `env:<environment name>`. For more information, see the [Datadog Tracing environments page](https://docs.datadoghq.com/tracing/environments/). |
-| `HEROKU_POSTGRES` | *Optional.* When set to `true` the Datadog Postgres check will be auto-configured from the DATABASE_URL environment variable. |
+| `DD_HEROKU_POSTGRES` | *Optional.* When set to `true` the Datadog Postgres check will be auto-configured from the DATABASE_URL environment variable. |
 
 For additional documentation, refer to the [Datadog Agent documentation](https://docs.datadoghq.com/agent/).
 

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -50,6 +50,7 @@ instances:
     username: ${BASH_REMATCH[1]}
     password: ${BASH_REMATCH[2]}
     dbname: ${BASH_REMATCH[5]}
+    use_psycopg2: True
 EOF
   fi
 fi

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -38,7 +38,7 @@ for file in "$APP_DATADOG_CONF_DIR"/*.yaml; do
 done
 
 # Auto-Configure Datadog for Postgres
-if [ "$HEROKU_POSTGRES" == "true" ]; then
+if [ "$DD_HEROKU_POSTGRES" == "true" ]; then
   POSTGREGEX='^postgres://([^:]+):([^@]+)@([^:]+):([^/]+)/(.*)$'
   if [[ $DATABASE_URL =~ $POSTGREGEX ]]; then
     cat << EOF > $DD_CONF_DIR/conf.d/postgres.d/conf.yaml


### PR DESCRIPTION
Configures the Datadog Postgres check by parsing the DATABASE_URL env
variable.

Possibly resolves issue #68