### PR TITLE
Removing unsupported env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ In addition to the environment variables shown above, there are a number of othe
 | `DD_PROCESS_AGENT` | *Optional.* The Datadog Process Agent is disabled by default. Set this to `true` to enable the Process Agent. |
 | `DD_SITE` | *Optional.* If you use the app.datadoghq.eu service, set this to `datadoghq.eu`. Defaults to `datadoghq.com`. |
 | `DD_AGENT_VERSION` | *Optional.* By default, the buildpack installs the latest version of the Datadog Agent available in the package repository. Use this variable to install older versions of the Datadog Agent (note that not all versions of the Agent may be available). |
-| `DD_SERVICE_ENV` | *Optional.* The Datadog Agent automatically tries to identify your environment by searching for a tag in the form `env:<environment name>`. For more information, see the [Datadog Tracing environments page](https://docs.datadoghq.com/tracing/environments/). |
 
 For additional documentation, refer to the [Datadog Agent documentation](https://docs.datadoghq.com/agent/).
 


### PR DESCRIPTION
Changes to the dd-trace-rb library have deprecated the DD_SERVICE_ENV
variable. See https://github.com/DataDog/dd-trace-rb/pull/101 for
more info.