### PR TITLE
Adding Trace Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,14 @@ In addition to the environment variables shown above, there are a number of othe
 | Setting | Description|
 | --- | --- |
 | `DD_API_KEY` | *Required.* Your API key is available from the [Datadog API integrations](https://app.datadoghq.com/account/settings#api) page. Note that this is the *API* key, not the application key. |
-| `DD_HOSTNAME` | *Deprecated.* **WARNING**: Setting the hostname manually may result in metrics continuity errors. It is recommended that you do *not* set this variable. Because dyno hosts are ephemeral it is recommended that you monitor based on the tags `dynoname` or `appname`. |
+| `DD_HOSTNAME` | **WARNING**: Setting the hostname manually may result in metrics continuity errors. It is strongly recommended that you do *not* set this variable. Because dyno hosts are ephemeral it is recommended that you monitor based on the tags `dynoname` or `appname`. |
 | `DD_DYNO_HOST` | *Optional.* Set to `true` to use the app and dyno name (e.g. `appname.web.1` or `appname.run.1234`) as the hostname. See the [hostname section](#hostname) below for more information. You must enable Heroku Labs Dyno Metadata to use this feature. Defaults to `false`. |
 | `DD_TAGS` | *Optional.* Sets additional tags provided as a comma-delimited string. For example, `heroku config:set DD_TAGS=simple-tag-0,tag-key-1:tag-value-1`. The buildpack automatically adds the tags `dyno` (the dyno name, e.g. `web.1`) and `dynotype` (the type of dyno, e.g `run` or `web`). See the ["Guide to tagging"](http://docs.datadoghq.com/guides/tagging/) for more information. |
 | `DD_HISTOGRAM_PERCENTILES` | *Optional.* Optionally set additional percentiles for your histogram metrics. See the [Histogram percentiles article](https://help.datadoghq.com/hc/en-us/articles/204588979-How-to-graph-percentiles-in-Datadog) for more information. |
 | `DISABLE_DATADOG_AGENT` | *Optional.* When set, the Datadog Agent will not be run. |
 | `DD_APM_ENABLED` | *Optional.* The Datadog Trace Agent (APM) is run by default. Set this to `false` to disable the Trace Agent. |
 | `DD_PROCESS_AGENT` | *Optional.* The Datadog Process Agent is disabled by default. Set this to `true` to enable the Process Agent. |
+| `DD_SITE` | *Optional.* If you use the app.datadoghq.eu service, set this to `datadoghq.eu`. Defaults to `datadoghq.com`. |
 | `DD_AGENT_VERSION` | *Optional.* By default, the buildpack installs the latest version of the Datadog Agent available in the package repository. Use this variable to install older versions of the Datadog Agent (note that not all versions of the Agent may be available). |
 | `DD_SERVICE_ENV` | *Optional.* The Datadog Agent automatically tries to identify your environment by searching for a tag in the form `env:<environment name>`. For more information, see the [Datadog Tracing environments page](https://docs.datadoghq.com/tracing/environments/). |
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ In addition to the environment variables shown above, there are a number of othe
 | `DD_APM_ENABLED` | *Optional.* The Datadog Trace Agent (APM) is run by default. Set this to `false` to disable the Trace Agent. |
 | `DD_PROCESS_AGENT` | *Optional.* The Datadog Process Agent is disabled by default. Set this to `true` to enable the Process Agent. |
 | `DD_SITE` | *Optional.* If you use the app.datadoghq.eu service, set this to `datadoghq.eu`. Defaults to `datadoghq.com`. |
-| `DD_APM_TRACE_SEARCH` | *Optional.* Enables configuration for [APM Trace Search & Analytics](https://www.datadoghq.com/blog/trace-search-high-cardinality-data/). Disabled by default. |
-| `DD_APM_SERVICE_NAME` | *Optional.* If `DD_APM_TRACE_SEARCH` is enabled, this value must be set to the name of your service in Datadog APM. |
+| `DD_APM_ANALYZED_SPANS` | *Optional.* Enable trace search by setting this to a comma-delimited list of analyzed spans. For example, `my-service|http.request: 1, my-service-2|flask.request: 1`. For more information, see, [the trace search documentation](https://docs.datadoghq.com/tracing/setup/?tab=agent630#trace-search) |
 | `DD_AGENT_VERSION` | *Optional.* By default, the buildpack installs the latest version of the Datadog Agent available in the package repository. Use this variable to install older versions of the Datadog Agent (note that not all versions of the Agent may be available). |
 | `DD_SERVICE_ENV` | *Optional.* The Datadog Agent automatically tries to identify your environment by searching for a tag in the form `env:<environment name>`. For more information, see the [Datadog Tracing environments page](https://docs.datadoghq.com/tracing/environments/). |
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In addition to the environment variables shown above, there are a number of othe
 | `DD_APM_ENABLED` | *Optional.* The Datadog Trace Agent (APM) is run by default. Set this to `false` to disable the Trace Agent. |
 | `DD_PROCESS_AGENT` | *Optional.* The Datadog Process Agent is disabled by default. Set this to `true` to enable the Process Agent. |
 | `DD_SITE` | *Optional.* If you use the app.datadoghq.eu service, set this to `datadoghq.eu`. Defaults to `datadoghq.com`. |
-| `DD_APM_ANALYZED_SPANS` | *Optional.* Enable trace search by setting this to a comma-delimited list of analyzed spans. For example, `my-service|http.request: 1, my-service-2|flask.request: 1`. For more information, see, [the trace search documentation](https://docs.datadoghq.com/tracing/setup/?tab=agent630#trace-search) |
+| `DD_APM_ANALYZED_SPANS` | *Optional.* Enable trace search by setting this to a comma-delimited list of analyzed spans. For example, `my-service|http.request, my-service-2|flask.request`. For more information, see, [the trace search documentation](https://docs.datadoghq.com/tracing/setup/?tab=agent630#trace-search) |
 | `DD_AGENT_VERSION` | *Optional.* By default, the buildpack installs the latest version of the Datadog Agent available in the package repository. Use this variable to install older versions of the Datadog Agent (note that not all versions of the Agent may be available). |
 | `DD_SERVICE_ENV` | *Optional.* The Datadog Agent automatically tries to identify your environment by searching for a tag in the form `env:<environment name>`. For more information, see the [Datadog Tracing environments page](https://docs.datadoghq.com/tracing/environments/). |
 

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -63,10 +63,13 @@ sed -i -e"s|^# apm_config:$|apm_config:|" "$DATADOG_CONF"
 # Add the log file location.
 sed -i -e"s|^apm_config:$|apm_config:\n    log_file: $DD_APM_LOG|" "$DATADOG_CONF"
 
-# If trace search has been added, enable the service name here.
-if [ -n "$DD_APM_TRACE_SEARCH" ]; then
-  sed -i -e"s|^apm_config:$|apm_config:\n    analyzed_spans:\n        $DD_APM_SERVICE_NAME\|http.request: 1|" $DATADOG_CONF
-else
+# If trace search has been added, enable the service names here.
+if [ -n "$DD_APM_ANALYZED_SPANS" ]; then
+  ANALYZED_SPANS="analyzed_spans:"
+  SPANS="$(sed "s/,[ ]\?/\\\n        /g" <<< "$DD_APM_ANALYZED_SPANS")"
+  ANALYZED_SPANS="$ANALYZED_SPANS\n        $SPANS"
+  sed -i "s/^apm_config:$/apm_config:\n    $ANALYZED_SPANS/" $DATADOG_CONF
+fi
 
 # Uncomment the Process Agent configs and enable.
 if [ "$DD_PROCESS_AGENT" == "true" ]; then

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -66,8 +66,8 @@ sed -i -e"s|^apm_config:$|apm_config:\n    log_file: $DD_APM_LOG|" "$DATADOG_CON
 # If trace search has been added, enable the service names here.
 if [ -n "$DD_APM_ANALYZED_SPANS" ]; then
   ANALYZED_SPANS="analyzed_spans:"
-  SPANS="$(sed "s/,[ ]\?/\\\n        /g" <<< "$DD_APM_ANALYZED_SPANS")"
-  ANALYZED_SPANS="$ANALYZED_SPANS\n        $SPANS"
+  SPANS="$(sed "s/,[ ]\?/: 1\\\n        /g" <<< "$DD_APM_ANALYZED_SPANS")"
+  ANALYZED_SPANS="$ANALYZED_SPANS\n        $SPANS: 1"
   sed -i "s/^apm_config:$/apm_config:\n    $ANALYZED_SPANS/" $DATADOG_CONF
 fi
 


### PR DESCRIPTION
This builds on the work done in #65 
Notable changes include:
- Simplified by removing the toggle env var. If analyzed spans exist, then we should automatically enable the feature.
- Made the string more agnostic for operation name per cjhin's comment in the original PR
- Allow for multiple analyzed spans. This will not likely see much use in a Heroku environment, but we should support it, since the Datadog Agent allows for it.