### PR TITLE
s/Github/GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ This project is open source (Apache 2 License), which means we're happy for you 
   heroku ps:copy /app/.apt/var/log/datadog/datadog-apm.log --dyno=<YOUR DYNO NAME>
   ```
 
-* Finally, you can open [a Github issue](https://github.com/DataDog/heroku-buildpack-datadog/issues).
+* Finally, you can open [a GitHub issue](https://github.com/DataDog/heroku-buildpack-datadog/issues).
 
 ### Pull requests
 


### PR DESCRIPTION
I'm a bit of a stickler for capitalization 😊

Same thing applies to https://docs.datadoghq.com/agent/basic_agent_usage/heroku/ under "More information", but I don't think that is in this repository.