### PR TITLE
Remove broken find command

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -106,8 +106,6 @@ fi
 
 # Ensure all check and librariy locations are findable in the Python path.
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7"
-# Recursively add packages to python path.
-find "$DD_PYTHONPATH"/embedded/lib/python*/site-packages -type d -exec DD_PYTHONPATH="{}":"$DD_PYTHONPATH" \;
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/site-packages:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/plat-linux2:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/lib-tk:$DD_PYTHONPATH"


### PR DESCRIPTION
The find command is broken and does not do what the comment indicates.

Example output:
```
find: '/app/.apt/opt/datadog-agent/embedded/lib/python2.7/embedded/lib/python*/site-packages': No such file or directory
```