### PR TITLE
Remove DD_APM_ANALYZED_SPANS

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ In addition to the environment variables shown above, there are a number of othe
 | `DD_APM_ENABLED` | *Optional.* The Datadog Trace Agent (APM) is run by default. Set this to `false` to disable the Trace Agent. |
 | `DD_PROCESS_AGENT` | *Optional.* The Datadog Process Agent is disabled by default. Set this to `true` to enable the Process Agent. |
 | `DD_SITE` | *Optional.* If you use the app.datadoghq.eu service, set this to `datadoghq.eu`. Defaults to `datadoghq.com`. |
-| `DD_APM_ANALYZED_SPANS` | *Optional.* Enable trace search by setting this to a comma-delimited list of analyzed spans. For example, `my-service|http.request, my-service-2|flask.request`. For more information, see, [the trace search documentation](https://docs.datadoghq.com/tracing/setup/?tab=agent630#trace-search) |
 | `DD_AGENT_VERSION` | *Optional.* By default, the buildpack installs the latest version of the Datadog Agent available in the package repository. Use this variable to install older versions of the Datadog Agent (note that not all versions of the Agent may be available). |
 
 For additional documentation, refer to the [Datadog Agent documentation](https://docs.datadoghq.com/agent/).

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -61,19 +61,19 @@ sed -i "s/^#   - role:database$/#   - role:database\n$TAGS/" "$DATADOG_CONF"
 # Uncomment APM configs and add the log file location.
 sed -i -e"s|^# apm_config:$|apm_config:|" "$DATADOG_CONF"
 # Add the log file location.
-sed -i -e"s|^apm_config:$|apm_config:\n    log_file: $DD_APM_LOG|" "$DATADOG_CONF"
+sed -i -e"s|^apm_config:$|apm_config:\n  log_file: $DD_APM_LOG|" "$DATADOG_CONF"
 
 # If trace search has been added, enable the service names here.
 if [ -n "$DD_APM_ANALYZED_SPANS" ]; then
   ANALYZED_SPANS="analyzed_spans:"
-  SPANS="$(sed "s/,[ ]\?/: 1\\\n        /g" <<< "$DD_APM_ANALYZED_SPANS")"
-  ANALYZED_SPANS="$ANALYZED_SPANS\n        $SPANS: 1"
-  sed -i "s/^apm_config:$/apm_config:\n    $ANALYZED_SPANS/" $DATADOG_CONF
+  SPANS="$(sed "s/,[ ]\?/: 1\\\n    /g" <<< "$DD_APM_ANALYZED_SPANS")"
+  ANALYZED_SPANS="$ANALYZED_SPANS\n    $SPANS: 1"
+  sed -i "s/^apm_config:$/apm_config:\n  $ANALYZED_SPANS/" $DATADOG_CONF
 fi
 
 # Uncomment the Process Agent configs and enable.
 if [ "$DD_PROCESS_AGENT" == "true" ]; then
-  sed -i -e"s|^# process_config:$|process_config:\n    enabled: true|" "$DATADOG_CONF"
+  sed -i -e"s|^# process_config:$|process_config:\n  enabled: true|" "$DATADOG_CONF"
 fi
 
 # For a list of env vars to override datadog.yaml, see:

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -63,14 +63,6 @@ sed -i -e"s|^# apm_config:$|apm_config:|" "$DATADOG_CONF"
 # Add the log file location.
 sed -i -e"s|^apm_config:$|apm_config:\n  log_file: $DD_APM_LOG|" "$DATADOG_CONF"
 
-# If trace search has been added, enable the service names here.
-if [ -n "$DD_APM_ANALYZED_SPANS" ]; then
-  ANALYZED_SPANS="analyzed_spans:"
-  SPANS="$(sed "s/,[ ]\?/: 1\\\n    /g" <<< "$DD_APM_ANALYZED_SPANS")"
-  ANALYZED_SPANS="$ANALYZED_SPANS\n    $SPANS: 1"
-  sed -i "s/^apm_config:$/apm_config:\n  $ANALYZED_SPANS/" $DATADOG_CONF
-fi
-
 # Uncomment the Process Agent configs and enable.
 if [ "$DD_PROCESS_AGENT" == "true" ]; then
   sed -i -e"s|^# process_config:$|process_config:\n  enabled: true|" "$DATADOG_CONF"


### PR DESCRIPTION
The agent now reads the env var `DD_APM_ANALYZED_SPANS` directly from the environment and no longer needs this code to inject it into the `datadog.yaml` config file.

To set an analyzed span, set the env var as:
`service-name|process=1,service2-name|process2=1`