### PR TITLE
Limit the depth of `find` when generating python path

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -99,7 +99,7 @@ fi
 # Ensure all check and librariy locations are findable in the Python path.
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7"
 # Recursively add packages to python path.
-DD_PYTHONPATH="$DD_PYTHONPATH:$(find "$DD_DIR/embedded/lib/python2.7/site-packages" -maxdepth 1 -type d -printf ":%p")"
+DD_PYTHONPATH="$DD_PYTHONPATH$(find "$DD_DIR/embedded/lib/python2.7/site-packages" -maxdepth 1 -type d -printf ":%p")"
 # Add other packages.
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/plat-linux2:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/lib-tk:$DD_PYTHONPATH"

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -99,7 +99,7 @@ fi
 # Ensure all check and librariy locations are findable in the Python path.
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7"
 # Recursively add packages to python path.
-DD_PYTHONPATH="$DD_PYTHONPATH:$(find "$DD_DIR/embedded/lib/python2.7/site-packages" -type d -printf ":%p")"
+DD_PYTHONPATH="$DD_PYTHONPATH:$(find "$DD_DIR/embedded/lib/python2.7/site-packages" -type d -maxdepth 1 -printf ":%p")"
 # Add other packages.
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/plat-linux2:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/lib-tk:$DD_PYTHONPATH"

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -99,7 +99,7 @@ fi
 # Ensure all check and librariy locations are findable in the Python path.
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7"
 # Recursively add packages to python path.
-DD_PYTHONPATH="$DD_PYTHONPATH:$(find "$DD_DIR/embedded/lib/python2.7/site-packages" -type d -maxdepth 1 -printf ":%p")"
+DD_PYTHONPATH="$DD_PYTHONPATH:$(find "$DD_DIR/embedded/lib/python2.7/site-packages" -maxdepth 1 -type d -printf ":%p")"
 # Add other packages.
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/plat-linux2:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/lib-tk:$DD_PYTHONPATH"


### PR DESCRIPTION
Previously this would recurse sub directories which could lead to include issues. 