### PR TITLE
Add startup for process agent

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -141,4 +141,10 @@ else
     echo "Starting Datadog Trace Agent on $DD_HOSTNAME"
     bash -c "$DD_DIR/embedded/bin/trace-agent -config $DATADOG_CONF 2>&1 &"
   fi
+
+  # The Process Agen must be run explicitly
+  if [ "$DD_PROCESS_AGENT" == "true" ]; then
+    echo "Starting Datadog Process Agent on $DD_HOSTNAME"
+    bash -c "$DD_DIR/embedded/bin/process-agent -config $DATADOG_CONF 2>&1 &"
+  fi
 fi

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -24,7 +24,7 @@ cp "$DATADOG_CONF.example" "$DATADOG_CONF"
 
 # Update the Datadog conf yaml with the correct conf.d and checks.d
 sed -i -e"s|^.*confd_path:.*$|confd_path: $DD_CONF_DIR/conf.d|" "$DATADOG_CONF"
-sed -i -e"s|^.*additional_checksd:.*$|additional_checksd: $DD_DIR/checks.d|" "$DATADOG_CONF"
+sed -i -e"s|^.*additional_checksd:.*$|additional_checksd: $DD_CONF_DIR/checks.d|" "$DATADOG_CONF"
 
 # Include application's datadog configs
 APP_DATADOG="/app/datadog"


### PR DESCRIPTION
The process agent no longer automatically starts by setting the config in the main Agent config yaml. This change starts the process agent explicitly.