### PR TITLE
Export DYNOTYPE environment variable

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -40,7 +40,7 @@ done
 
 # Add tags to the config file
 DYNOHOST="$(hostname )"
-DYNOTYPE=${DYNO%%.*}
+export DYNOTYPE=${DYNO%%.*}
 TAGS="tags:\n  - dyno:$DYNO\n  - dynotype:$DYNOTYPE"
 
 if [ -n "$HEROKU_APP_NAME" ]; then


### PR DESCRIPTION
Export DYNOTYPE environment variable to make it available in the prerun script - https://github.com/DataDog/heroku-buildpack-datadog#prerun-script.
Fixes https://github.com/DataDog/heroku-buildpack-datadog/issues/121.