### PR TITLE
Fix tag injection

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -56,7 +56,7 @@ if [ -n "$DD_TAGS" ]; then
 fi
 
 # Inject tags after example tags.
-sed -i "s/^#   - role:database$/#   - role:database\n$TAGS/" "$DATADOG_CONF"
+sed -i "s/^#   - <TAG_KEY>:<TAG_VALUE>$/#   - <TAG_KEY>:<TAG_VALUE>\n$TAGS/" "$DATADOG_CONF"
 
 # Uncomment APM configs and add the log file location.
 sed -i -e"s|^# apm_config:$|apm_config:|" "$DATADOG_CONF"

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -56,6 +56,9 @@ if [ -n "$DD_TAGS" ]; then
 fi
 
 # Inject tags after example tags.
+# Config files for agent versions 6.11 and earlier:
+sed -i "s/^#   - role:database$/#   - role:database\n$TAGS/" "$DATADOG_CONF"
+# Agent versions 6.12 and later:
 sed -i "s/^#   - <TAG_KEY>:<TAG_VALUE>$/#   - <TAG_KEY>:<TAG_VALUE>\n$TAGS/" "$DATADOG_CONF"
 
 # Uncomment APM configs and add the log file location.

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -59,7 +59,7 @@ fi
 # Config files for agent versions 6.11 and earlier:
 sed -i "s/^#   - role:database$/#   - role:database\n$TAGS/" "$DATADOG_CONF"
 # Agent versions 6.12 and later:
-sed -i "s/^#   - <TAG_KEY>:<TAG_VALUE>$/#   - <TAG_KEY>:<TAG_VALUE>\n$TAGS/" "$DATADOG_CONF"
+sed -i "s/^\(## @param tags\)/$TAGS\n\1/" "$DATADOG_CONF"
 
 # Uncomment APM configs and add the log file location.
 sed -i -e"s|^# apm_config:$|apm_config:|" "$DATADOG_CONF"


### PR DESCRIPTION
In DataDog agent versions 6.12 and upwards the "role:database" commented example tag has been replaced with "<TAG_KEY>:<TAG_VALUE>". This means that the `$TAGS` variable is no longer getting correctly injected into the configuration.

**Line in the commit in `datadog-agent`**: https://github.com/DataDog/datadog-agent/commit/39e8b941c333020d698c4c11dc0474d76adc187e#diff-99e505a5e29849d8a342596285e284a1L53 