### PR TITLE
Removing documentation front matters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,4 @@
----
-title: Datadog Heroku Buildpack
-kind: documentation
-aliases:
-- /developers/faq/how-do-i-collect-metrics-from-heroku-with-datadog
----
+# Datadog Heroku Buildpack
 
 This [Heroku buildpack][1] installs the Datadog Agent in your Heroku dyno to collect system metrics, custom application metrics, and traces. To collect custom application metrics or traces, include the language appropriate [DogStatsD or Datadog APM library][2] in your application.
 


### PR DESCRIPTION
Removes Datadog documentation front maters since now they can be injected directly during doc build.