### PR TITLE
Match the full line when looking for a version number to avoid partial matches

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -72,7 +72,7 @@ if [ -f "$ENV_DIR/DD_AGENT_VERSION" ]; then
   AGENT_VERSIONS=$(sed 's/Version: 1://g' <<<"$AGENT_VERSIONS")
 
   # If specified version doesn't exist, list available versions.
-  if [ -z $(echo "$AGENT_VERSIONS" | grep "$DD_AGENT_VERSION") ]; then
+  if [ -z $(echo "$AGENT_VERSIONS" | grep -x "$DD_AGENT_VERSION") ]; then
     topic "ERROR: Version \"$DD_AGENT_VERSION\" was not found."
     echo "Available versions:" | indent
     echo "$AGENT_VERSIONS" | indent


### PR DESCRIPTION
When looking for a version in the apt cache, it would match a partial match, instead of failing, then the script would fail later, as the actual requested version is not found in the cache.

Matching the full line fixes the issue.