### PR TITLE
Add the agent embedded lib folder to LD_LIBRARY_PATH before calling agent version

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -129,7 +129,7 @@ if [ -n "$DISABLE_DATADOG_AGENT" ]; then
   echo "The Datadog Agent has been disabled. Unset the DISABLE_DATADOG_AGENT or set missing environment variables."
 else
   # Get the Agent version number
-  DD_VERSION="$(expr "$($DD_BIN_DIR/agent version)" : 'Agent \([0-9]\+\.[0-9]\+.[0-9]\+\)')"
+  DD_VERSION="$(expr "$(bash -c "LD_LIBRARY_PATH=\"$APT_DIR/opt/datadog-agent/embedded/lib:$LD_LIBRARY_PATH\" $DD_BIN_DIR/agent version")" : 'Agent \([0-9]\+\.[0-9]\+.[0-9]\+\)')"
 
   # Prior to Agent 6.4.1, the command is "start"
   RUN_VERSION="6.4.1"


### PR DESCRIPTION
Starting any agent above 6.4 was giving a deprecation warning when starting with `agent start` as we never not getting the version correctly as `agent version` failed with a missing library.

Adding the embedded lib folder to LD_LIBRARY_PATH when calling `agent version` fixes the issue.

Fixes #126 