### PR TITLE
For agent versions that contain both python 2 and 3, remove 1 version based on the value of PYTHON_VERSION env variable

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -102,6 +102,26 @@ fi
 topic "Installing Datadog Agent"
 dpkg -x "$DEB" "$APT_DIR"
 
+# Removing unneeded content
+rm -rf "$APT_DIR"/opt/datadog-agent/sources \
+       "$APT_DIR"/opt/datadog-agent/embedded/share/doc \
+       "$APT_DIR"/opt/datadog-agent/embedded/share/man
+
+if [ -f "$ENV_DIR/PYTHON_VERSION" ]; then
+  PYTHON_VERSION=$(cat "$ENV_DIR/PYTHON_VERSION")
+  if [ "$PYTHON_VERSION" != "2" ] && [ "$PYTHON_VERSION" != "3" ]; then
+    topic "ERROR: Wrong Python version: \"$PYTHON_VERSION\"."
+    echo "Set PYTHON_VERSION to either 2 or 3." | indent
+    exit 1
+  fi
+else
+  PYTHON_VERSION="2" # if not specified, we default to Python 2
+fi
+
+# We remove the unneeded version of Python
+if [ "$PYTHON_VERSION" = "2" ]; then rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/python3.*; fi
+if [ "$PYTHON_VERSION" = "3" ]; then rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/python2.*; fi
+
 # Rewrite package-config files
 find "$APT_DIR" -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$APT_DIR"'\1!g'
 

--- a/bin/compile
+++ b/bin/compile
@@ -107,20 +107,31 @@ rm -rf "$APT_DIR"/opt/datadog-agent/sources \
        "$APT_DIR"/opt/datadog-agent/embedded/share/doc \
        "$APT_DIR"/opt/datadog-agent/embedded/share/man
 
-if [ -f "$ENV_DIR/PYTHON_VERSION" ]; then
-  PYTHON_VERSION=$(cat "$ENV_DIR/PYTHON_VERSION")
-  if [ "$PYTHON_VERSION" != "2" ] && [ "$PYTHON_VERSION" != "3" ]; then
-    topic "ERROR: Wrong Python version: \"$PYTHON_VERSION\"."
-    echo "Set PYTHON_VERSION to either 2 or 3." | indent
-    exit 1
-  fi
+# Prior to Agent 6.14 there was only 1 python version
+DD_AGENT_MULT_PYTHON_VERSION="6.14"
+if [ "$DD_AGENT_VERSION" == "$(echo -e "$DD_AGENT_MULT_PYTHON_VERSION\n$DD_AGENT_VERSION" | sort -V | head -n1)" ]; then
+  NUM_PYTHON="1"
 else
-  PYTHON_VERSION="2" # if not specified, we default to Python 2
+  NUM_PYTHON="2"
 fi
 
-# We remove the unneeded version of Python
-if [ "$PYTHON_VERSION" = "2" ]; then rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/python3.*; fi
-if [ "$PYTHON_VERSION" = "3" ]; then rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/python2.*; fi
+# If we have 2 python versions, we remove the one that wasn't selected
+if [ "$NUM_PYTHON" = "2" ]; then
+  if [ -f "$ENV_DIR/PYTHON_VERSION" ]; then
+    PYTHON_VERSION=$(cat "$ENV_DIR/PYTHON_VERSION")
+    if [ "$PYTHON_VERSION" != "2" ] && [ "$PYTHON_VERSION" != "3" ]; then
+      topic "ERROR: Wrong Python version: \"$PYTHON_VERSION\"."
+      echo "Set PYTHON_VERSION to either 2 or 3." | indent
+      exit 1
+    fi
+  else
+    PYTHON_VERSION="2" # if not specified, we default to Python 2
+  fi
+
+  # We remove the unneeded version of Python
+  if [ "$PYTHON_VERSION" = "2" ]; then rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/python3.*; fi
+  if [ "$PYTHON_VERSION" = "3" ]; then rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/python2.*; fi
+fi
 
 # Rewrite package-config files
 find "$APT_DIR" -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$APT_DIR"'\1!g'

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -105,7 +105,11 @@ if [ "$DD_DISABLE_HOST_METRICS" == "true" ]; then
 fi
 
 # Find if the Python folder is 2 or 3
-PYTHON_DIR=$(find "$DD_DIR/embedded/lib/" -maxdepth 1 -type d -name "python[2-3]\.[0-9]"  -printf "%f")
+PYTHON_DIR=$(find "$DD_DIR/embedded/lib/" -maxdepth 1 -type d -name "python[2-3]\.[0-9]" -printf "%f")
+PYTHON_VERSION=$(echo $PYTHON_DIR | sed -n -e 's/^python\([2-3]\)\.[0-9]/\1/p')
+
+# If Python version is 3, it has to be specified in the configuration file
+if [ "$PYTHON_VERSION" = "3" ]; then echo 'python_version: 3' >> $DATADOG_CONF; fi
 
 # Ensure all check and library locations are findable in the Python path.
 DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR"

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -104,14 +104,17 @@ if [ "$DD_DISABLE_HOST_METRICS" == "true" ]; then
   find "$DD_CONF_DIR"/conf.d -name "conf.yaml.default" -exec mv {} {}_disabled \;
 fi
 
-# Ensure all check and librariy locations are findable in the Python path.
-DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7"
+# Find if the Python folder is 2 or 3
+PYTHON_DIR=$(find "$DD_DIR/embedded/lib/" -maxdepth 1 -type d -name "python[2-3]\.[0-9]"  -printf "%f")
+
+# Ensure all check and library locations are findable in the Python path.
+DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR"
 # Recursively add packages to python path.
-DD_PYTHONPATH="$DD_PYTHONPATH$(find "$DD_DIR/embedded/lib/python2.7/site-packages" -maxdepth 1 -type d -printf ":%p")"
+DD_PYTHONPATH="$DD_PYTHONPATH$(find "$DD_DIR/embedded/lib/$PYTHON_DIR/site-packages" -maxdepth 1 -type d -printf ":%p")"
 # Add other packages.
-DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/plat-linux2:$DD_PYTHONPATH"
-DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/lib-tk:$DD_PYTHONPATH"
-DD_PYTHONPATH="$DD_DIR/embedded/lib/python2.7/lib-dynload:$DD_PYTHONPATH"
+DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR/plat-linux2:$DD_PYTHONPATH"
+DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR/lib-tk:$DD_PYTHONPATH"
+DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR/lib-dynload:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/bin/agent/dist:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/embedded/lib:$DD_PYTHONPATH"
 

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -113,8 +113,7 @@ if [ "$PYTHON_VERSION" = "3" ]; then echo 'python_version: 3' >> $DATADOG_CONF; 
 
 # Ensure all check and library locations are findable in the Python path.
 DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR"
-# Recursively add packages to python path.
-DD_PYTHONPATH="$DD_PYTHONPATH$(find "$DD_DIR/embedded/lib/$PYTHON_DIR/site-packages" -maxdepth 1 -type d -printf ":%p")"
+DD_PYTHONPATH="$DD_PYTHONPATH:$DD_DIR/embedded/lib/$PYTHON_DIR/site-packages"
 # Add other packages.
 DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR/plat-linux2:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR/lib-tk:$DD_PYTHONPATH"


### PR DESCRIPTION
Starting with the version 6.14 of the agent, it will ship with both python2 and python3 embedded. As this would make the slug too big, we remove one of the versions.

The user of the buildpack can select which one they want to keep by setting the env variable PYTHON_VERSION to "2" or "3". If it is not set, it defaults to python2.

For agent versions prior to 6.14, it would just keep python2 and will ignore any PYTHON_VERSION settings.

To test with the nightly builds, source list needs to be changed to point to:

```
deb [trusted=yes] http://apt.datad0g.com/ nightly main 6
```

This has been tested with the following versions and settings:

Test matrix:

| DD_AGENT_VERSION  | PYTHON_VERSION  | UBUNTU | COMPILE | RUN | NOTES |
|---|---|---|---|---|---|
|  |  | 16 | ✅  | ✅  | Successfully pinned 6.13. Successfully started with python2 |
|  |  | 18 | ✅ | ✅ | Successfully pinned 6.13. Successfully started with python2 |
|  | 2 | 16 | ✅  | ✅  | Successfully pinned 6.13. Successfully started with python2 |
|  | 2 | 18 | ✅ | ✅  | Successfully pinned 6.13. Successfully started with python2 |
|  | 3 | 16 | ✅  | ✅  | Successfully pinned 6.13. Successfully ignored the PYTHON_VERSION env variable and started with version 2 |
|  | 3 | 18 |  ✅ | ✅  | Successfully pinned 6.13. Successfully ignored the PYTHON_VERSION env variable and started with version 2 |
| 6.4.1-1 |  | 16 | ✅ | ✅| |
| 6.4.1-1 |  | 18 | ✅ | ✅| |
| 6.4.1-1 | 2 | 16 | ✅ | ✅ |  |
| 6.4.1-1 | 2 | 18 | ✅ | ✅ | |
| 6.4.1-1 | 3 | 16 | ✅ | ✅ | Successfully ignored the PYTHON_VERSION env variable and started with version 2 |
| 6.4.1-1 | 3 | 18 | ✅  | ✅  | Successfully ignored the PYTHON_VERSION env variable and started with version 2 |
| 6.12.0-1 |  | 16 |  ✅| ✅  | |
| 6.12.0-1 |  | 18 | ✅ | ✅  | |
| 6.12.0-1 | 2 | 16 | ✅ | ✅  | |
| 6.12.0-1 | 2 | 18 | ✅ | ✅ | |
| 6.12.0-1 | 3 | 16 |  ✅ |  ✅| Started with 2. Successfully ignored the PYTHON_VERSION env variable. |
| 6.12.0-1 | 3 | 18 | ✅ |  ✅ | Started with 2. Successfully ignored the PYTHON_VERSION env variable. |
| 6.14.0~devel.git.57.82c7fb3-1 |  | 16 |  ✅ | ✅| Defaulted successfully to python2. Removed python3. |
| 6.14.0~devel.git.57.82c7fb3-1 |  | 18 |  ✅ | ✅| Defaulted successfully to python2. Removed python3. |
| 6.14.0~devel.git.57.82c7fb3-1 | 2 | 16 | ✅  | ✅  | Removed python3. Started with python2 |
| 6.14.0~devel.git.57.82c7fb3-1 | 2 | 18 | ✅  | ✅  | Removed python3. Started with python2|
| 6.14.0~devel.git.57.82c7fb3-1 | 3 | 16 | ✅  | ✅  | Removed python2. Started with python3. |
| 6.14.0~devel.git.57.82c7fb3-1 | 3 | 18 | ✅  | ✅  | Removed python2. Started with python3.|
