### PR TITLE
Unit tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,33 @@ Here are some tips to keep in mind when submitting a PR:
 * Summarize your PR with an explanatory title and a message describing your changes. Cross-reference any related bugs/PRs and provide steps for testing when appropriate.
 * Write meaningful commit messages. The commit message should describe the reason for the change and give extra details that will allow someone later on to understand in 5 seconds the thing you've been working on for a day.
 * Rebase your changes on `master` and **squash** your commits whenever possible—it keeps the history clean, and it's easier to revert later if necessary.
+
+### Running the tests
+
+This project comes with a set of tests to ensure that changes don't break the buildpack for current users. The tests are written using the [Heroku Buildpack Testrunner](https://github.com/heroku/heroku-buildpack-testrunner).
+
+To run the tests create a Heroku application that uses the [Heroku Buildpack Testrunner](https://github.com/heroku/heroku-buildpack-testrunner) as Buildpack in the Datadog Heroku Buildpack Git repository folder:
+
+```shell
+git clone https://github.com/DataDog/heroku-buildpack-datadog.git
+cd heroku-buildpack-datadog
+heroku create --buildpack https://github.com/heroku/heroku-buildpack-testrunner
+````
+
+Once the testrunner is set as your buildpack's buildpack, push it to Heroku. This will automatically download and install shUnit2 and create a tests process for you:
+
+```shell
+git push heroku master
+```
+
+The tests execute the Datadog agent, so this new Heroku application will need to have your `DD_API_KEY` environment variable set for the tests to run correctly:
+
+```shell
+heroku config:set DD_API_KEY=<your_api_key>
+```
+
+Now, you can run your tests on Heroku:
+
+```shell
+heroku run tests
+```

--- a/app.json
+++ b/app.json
@@ -1,0 +1,19 @@
+{
+  "name": "Datadog Agent Heroku Buildpack",
+  "description": "This Heroku Buildpack installs the Datadog Agent in your Heroku dyno to collect system metrics, custom application metrics, and traces",
+  "scripts": {
+    "test": ".buildpack-testrunner/bin/run ."
+  },
+  "buildpacks": [
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-testrunner"
+    }
+  ],
+  "environments": {
+    "test": {
+      "env": {
+        "SHUNIT_HOME": "/app/.shunit2"
+      }
+    }
+  }
+}

--- a/test/compile_and_run.sh
+++ b/test/compile_and_run.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+. ${BUILDPACK_TEST_RUNNER_HOME}/lib/test_utils.sh
+
+
+getAvailableVersions()
+{
+  APT_DIR="$HOME/.apt" APT_CACHE_DIR="$CACHE_DIR/apt/cache"
+  APT_STATE_DIR="$CACHE_DIR/apt/state"
+  mkdir -p "$APT_CACHE_DIR/archives/partial"
+  mkdir -p "$APT_STATE_DIR/lists/partial"
+  mkdir -p "$APT_DIR"
+  APT_REPO_FILE="${BUILDPACK_HOME}/etc/datadog.list"
+  APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR -o Dir::Etc::SourceList=$APT_REPO_FILE"
+  apt-get $APT_OPTIONS update
+  AGENT_VERSIONS=$(apt-cache $APT_OPTIONS show datadog-agent | grep "Version: " | sed 's/Version: 1://g')
+}
+
+compileAndRunVersion()
+{
+
+  echo $1 > "${ENV_DIR}/DD_AGENT_VERSION"
+  echo "Testing Datadog Agent version $1"
+  compile
+  assertCaptured "Installing dependencies"
+  assertCaptured "Downloading Datadog Agent $1"
+  assertCaptured "Installing Datadog Agent"
+  assertCaptured "Installing Datadog runner"
+
+  export HOME=${BUILD_DIR}
+  chmod +x ${BUILDPACK_HOME}/extra/datadog.sh 
+  capture ${BUILDPACK_HOME}/extra/datadog.sh
+  assertFileNotContains "error while loading shared libraries" ${STD_ERR}
+  assertFileNotContains "Could not initialize Python" ${STD_ERR}
+  assertCaptured "Starting Datadog Agent"
+  assertCaptured "Starting Datadog Trace Agent"
+
+}
+
+testReleasedVersions()
+{
+  getAvailableVersions
+
+  for VERSION in ${AGENT_VERSIONS}; do
+    compileAndRunVersion $VERSION
+  done 
+}
+
+testLatestNightlyVersion()
+{
+  echo "deb [trusted=yes] http://apt.datad0g.com/ nightly main 6" > "${BUILDPACK_HOME}/etc/datadog.list"
+  getAvailableVersions
+  VERSION="$(echo ${AGENT_VERSIONS} | head -n1 | awk '{print $1;}')"
+
+  compileAndRunVersion $VERSION
+ 
+}

--- a/test/compile_and_run_test.sh
+++ b/test/compile_and_run_test.sh
@@ -34,6 +34,7 @@ compileAndRunVersion()
   assertFileNotContains "Could not initialize Python" ${STD_ERR}
   assertCaptured "Starting Datadog Agent"
   assertCaptured "Starting Datadog Trace Agent"
+  assertNotCaptured "The Datadog Agent has been disabled"
 
 }
 


### PR DESCRIPTION
This PR adds unit tests based on the [Heroku Buildpack Testrunner framework](https://github.com/heroku/heroku-buildpack-testrunner).

The tests will, for every released agent version available in the stable apt repo, and for the latest agent version in the nightly repo:

1) Do the `compile` step of the buildpack and assert for lack of messages and expected messages (right now the number of assertions is not big, but will catch the most common failures)
2) start the agent, and check for error messages and assert expected messages

The PR also includes an `app.json` file, for the integration of the tests with Heroku CI