### PR TITLE
Fix LD_LIBRARY_PATH issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,5 +69,5 @@ heroku run tests
 
 ### Modifying `datadog.sh`
 
-The wrapper that runs the agent when a dyno gets started, `datadog.sh`, gets sourced by Heroku, before running the dyno's command.
-Exporting environment variables that can conflict with Heroku's runtime in that file is discouraged (e.g `LD_LIBRARY_PATH`, `PYTHONPATH`).
+`datadog.sh` is a wrapper that runs the Agent when a dyno is started. It is sourced before running the command in the dyno's procfile.
+Exporting environment variables in `datadog.sh` that can conflict with Heroku's runtime is discouraged (e.g `LD_LIBRARY_PATH`, `PYTHONPATH`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,3 +66,8 @@ Now, you can run your tests on Heroku:
 ```shell
 heroku run tests
 ```
+
+### Modifying `datadog.sh`
+
+The wrapper that runs the agent when a dyno gets started, `datadog.sh`, gets sourced by Heroku, before running the dyno's command.
+Exporting environment variables that can conflict with Heroku's runtime in that file is discouraged (e.g `LD_LIBRARY_PATH`, `PYTHONPATH`).

--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ To save slug space, the `trace-agent` and `process-agent` optional binaries are 
 
 To reduce your slug size, make sure that `DD_APM_ENABLED` is set to `false`, if you are not using APM features; and `DD_PROCESS_AGENT` is not set to `true`, if you are not using process monitoring.
 
+## Debugging
+
+To run any of the information/debugging commands listed in the [Agent's documentation](https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information) use the `agent-wrapper` command.
+
+For example, to display the status of your Datadog Agent and enabled integrations, run:
+
+```
+agent-wrapper status
+```
+
 ## Heroku log collection
 
 The Heroku Datadog buildpack does not collect logs. To set up log collection, see the [dedicated guide][17].

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ To reduce your slug size, make sure that `DD_APM_ENABLED` is set to `false`, if 
 
 ## Debugging
 
-To run any of the information/debugging commands listed in the [Agent's documentation](https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information) use the `agent-wrapper` command.
+To run any of the information/debugging commands listed in the [Agent's documentation][21] use the `agent-wrapper` command.
 
 For example, to display the status of your Datadog Agent and enabled integrations, run:
 
@@ -188,3 +188,4 @@ Make sure you have `DD_DYNO_HOST` set to `true` and that `HEROKU_APP_NAME` has a
 [18]: https://docs.datadoghq.com/developers/libraries/#heroku
 [19]: https://github.com/DataDog/heroku-buildpack-datadog/releases
 [20]: https://devcenter.heroku.com/articles/dyno-metadata
+[21]: https://docs.datadoghq.com/agent/guide/agent-commands/?tab=agentv6#agent-status-and-information

--- a/bin/compile
+++ b/bin/compile
@@ -183,3 +183,8 @@ topic "Installing Datadog runner"
 mkdir -p "$BUILD_DIR/.profile.d"
 cp "$BUILDPACK_DIR/extra/datadog.sh" "$BUILD_DIR/.profile.d/"
 chmod +x "$BUILD_DIR/.profile.d/datadog.sh"
+# Install the debug wrapper
+topic "Installing Datadog runner"
+mkdir -p "$BUILD_DIR/datadog"
+cp "$BUILDPACK_DIR/extra/agent-wrapper" "$APT_DIR/opt/datadog-agent/bin/agent/"
+chmod +x "$APT_DIR/opt/datadog-agent/bin/agent/agent-wrapper"

--- a/bin/compile
+++ b/bin/compile
@@ -184,7 +184,6 @@ mkdir -p "$BUILD_DIR/.profile.d"
 cp "$BUILDPACK_DIR/extra/datadog.sh" "$BUILD_DIR/.profile.d/"
 chmod +x "$BUILD_DIR/.profile.d/datadog.sh"
 # Install the debug wrapper
-topic "Installing Datadog runner"
-mkdir -p "$BUILD_DIR/datadog"
+topic "Installing Datadog agent wrapper"
 cp "$BUILDPACK_DIR/extra/agent-wrapper" "$APT_DIR/opt/datadog-agent/bin/agent/"
 chmod +x "$APT_DIR/opt/datadog-agent/bin/agent/agent-wrapper"

--- a/extra/agent-wrapper
+++ b/extra/agent-wrapper
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Run the Datadog Agent with the selected command 
+bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_BIN_DIR/agent -c $DATADOG_CONF "$@" "

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -3,14 +3,16 @@
 # Setup Locations
 APT_DIR="$HOME/.apt"
 DD_DIR="$APT_DIR/opt/datadog-agent"
-DD_BIN_DIR="$DD_DIR/bin/agent"
+# Export DD_BIN_DIR to be used by the wrapper
+export DD_BIN_DIR="$DD_DIR/bin/agent"
 DD_LOG_DIR="$APT_DIR/var/log/datadog"
 DD_CONF_DIR="$APT_DIR/etc/datadog-agent"
-DATADOG_CONF="$DD_CONF_DIR/datadog.yaml"
+export DATADOG_CONF="$DD_CONF_DIR/datadog.yaml"
 
 # Update Env Vars with new paths for apt packages
 export PATH="$APT_DIR/usr/bin:$DD_BIN_DIR:$PATH"
-DD_LD_LIBRARY_PATH="$APT_DIR/opt/datadog-agent/embedded/lib:$APT_DIR/usr/lib/x86_64-linux-gnu:$APT_DIR/usr/lib"
+# Export agent's LD_LIBRARY_PATH to be used by the agent-wrapper
+export DD_LD_LIBRARY_PATH="$APT_DIR/opt/datadog-agent/embedded/lib:$APT_DIR/usr/lib/x86_64-linux-gnu:$APT_DIR/usr/lib"
 
 # Set Datadog configs
 export DD_LOG_FILE="$DD_LOG_DIR/datadog.log"
@@ -123,7 +125,8 @@ DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR/plat-linux2:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR/lib-tk:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR/lib-dynload:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/bin/agent/dist:$DD_PYTHONPATH"
-DD_PYTHONPATH="$DD_DIR/embedded/lib:$DD_PYTHONPATH"
+# Export agent's PYTHONPATH be used by the agent-wrapper
+export DD_PYTHONPATH="$DD_DIR/embedded/lib:$DD_PYTHONPATH"
 
 # Give applications a chance to modify env vars prior to running.
 # Note that this can modify existing env vars or perform other actions (e.g. modify the conf file).

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -11,9 +11,6 @@ DATADOG_CONF="$DD_CONF_DIR/datadog.yaml"
 # Update Env Vars with new paths for apt packages
 export PATH="$APT_DIR/usr/bin:$DD_BIN_DIR:$PATH"
 DD_LD_LIBRARY_PATH="$APT_DIR/opt/datadog-agent/embedded/lib:$APT_DIR/usr/lib/x86_64-linux-gnu:$APT_DIR/usr/lib"
-export LIBRARY_PATH="$LIBRARY_PATH:$APT_DIR/usr/lib/x86_64-linux-gnu:$APT_DIR/usr/lib"
-export INCLUDE_PATH="$APT_DIR/usr/include:$APT_DIR/usr/include/x86_64-linux-gnu:$INCLUDE_PATH"
-export PKG_CONFIG_PATH="$APT_DIR/usr/lib/x86_64-linux-gnu/pkgconfig:$APT_DIR/usr/lib/pkgconfig:$PKG_CONFIG_PATH"
 
 # Set Datadog configs
 export DD_LOG_FILE="$DD_LOG_DIR/datadog.log"


### PR DESCRIPTION
Things included in this PR:

* Unexported `LD_LIBRARY_PATH` from `datadog.sh`. `datadog.sh` is sourced by Heroku before  executing the dyno’s command, so exporting `LD_LIBRARY_PATH` would conflict with Heroku's environment. Added contribution documentation about it.
* Removed exporting compilation link paths
* Created an `agent-wrapper` command to allow users to run agent debugging commands. Added user documentation about it.