### PR TITLE
Added a buildpackversion tag to the default tags to send to Datadog

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -40,7 +40,8 @@ done
 # Add tags to the config file
 DYNOHOST="$(hostname )"
 DYNOTYPE=${DYNO%%.*}
-TAGS="tags:\n  - dyno:$DYNO\n  - dynotype:$DYNOTYPE"
+BUILDPACKVERSION="dev"
+TAGS="tags:\n  - dyno:$DYNO\n  - dynotype:$DYNOTYPE\n  - buildpackversion:$BUILDPACKVERSION"
 
 if [ -n "$HEROKU_APP_NAME" ]; then
   TAGS="$TAGS\n  - appname:$HEROKU_APP_NAME"


### PR DESCRIPTION
Added a buildpackversion tag to the default tags sent to Datadog. We would need to change it to the actual version before releasing.