### PR TITLE
Add pip and setuptools paths to pythonpath for python2

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -126,6 +126,14 @@ DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR/plat-linux2:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR/lib-tk:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR/lib-dynload:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/bin/agent/dist:$DD_PYTHONPATH"
+
+# For Python2 we need to add explicitely pip and setuptools dependencies
+if [ "$DD_PYTHON_VERSION" = "2" ]; then
+  PIP_PATH=$(find "$DD_DIR/embedded/lib/$PYTHON_DIR/site-packages" -maxdepth 1 -name pip*egg)
+  SETUPTOOLS_PATH=$(find "$DD_DIR/embedded/lib/$PYTHON_DIR/site-packages" -maxdepth 1 -name setuptools*egg)
+  DD_PYTHONPATH="$DD_PYTHONPATH:$SETUPTOOLS_PATH:$PIP_PATH"
+fi
+
 # Export agent's PYTHONPATH be used by the agent-wrapper
 export DD_PYTHONPATH="$DD_DIR/embedded/lib:$DD_PYTHONPATH"
 


### PR DESCRIPTION
Fixes #104 

For Python2 there are 2 additional paths that need to be added to pythonpath for some integrations (like mcache) to work correctly.