### PR TITLE
1.12 release (pin to agent 6.15.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased & outstanding issues]
 - Non-https repo url and apt fetching
 
+## [1.12] - 2019-12-13
+
+### Added
+- Datadog agent pinned version is now `6.15.1`
+- Added a deprecation warning if users are using Python 2 in 6.x.
+
+### Fixed
+- Fixed `datadog.sh` to run correctly in flynn.io.
+
 ## [1.11] - 2019-12-05
 
 ### Added

--- a/bin/compile
+++ b/bin/compile
@@ -160,6 +160,11 @@ if [ "$NUM_PYTHON" = "2" ]; then
 
   # We remove the unneeded version of Python
   if [ "$DD_PYTHON_VERSION" = "2" ]; then
+    topic "*********************************** WARNING ************************************"
+    echo "Python 2 will be deprecated soon. Agent 7.x ships with Python 3 only." | indent
+    echo "If you don't run custom checks or those are Python 3 ready, you can" | indent
+    echo "move to Python 3 now by setting DD_PYTHON_VERSION to 3 and compiling your slug." | indent
+    echo "********************************************************************************" | indent
     rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/python3.*
     rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/libpython3*
     rm "$APT_DIR"/opt/datadog-agent/embedded/bin/pip3*

--- a/bin/compile
+++ b/bin/compile
@@ -84,7 +84,7 @@ else
   # If no version is explicitly set, do so here.
   # In order to prevent unforseen issues from new Agent releases,
   # we now specify a default version in this buildpack.
-  DD_AGENT_VERSION="6.14.0-1"
+  DD_AGENT_VERSION="6.15.1-1"
 fi
 # Set the  specified version.
 PACKAGE="datadog-agent=1:$DD_AGENT_VERSION"

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -40,7 +40,7 @@ done
 # Add tags to the config file
 DYNOHOST="$(hostname )"
 DYNOTYPE=${DYNO%%.*}
-BUILDPACKVERSION="dev"
+BUILDPACKVERSION="1.12"
 TAGS="tags:\n  - dyno:$DYNO\n  - dynotype:$DYNOTYPE\n  - buildpackversion:$BUILDPACKVERSION"
 
 if [ -n "$HEROKU_APP_NAME" ]; then


### PR DESCRIPTION
This PRs prepares for buildpack release 1.12. It includes moving to agent 6.15.1 as pinned version, and a warning for people running python 2 and agent 6.13 onwards.

This release assumes #156 to be merged as well prior to release.