### PR TITLE
Move to 6.18 and 7.18 as pinned versions

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,8 +11,8 @@ set -o pipefail
 # set -x
 
 # Set agent pinned version
-DD_AGENT_PINNED_VERSION_6="6.17.0-1"
-DD_AGENT_PINNED_VERSION_7="7.17.0-1"
+DD_AGENT_PINNED_VERSION_6="6.18.0-1"
+DD_AGENT_PINNED_VERSION_7="7.18.0-1"
 
 # Parse and derive params
 BUILD_DIR=$1

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -18,6 +18,7 @@ export DD_LD_LIBRARY_PATH="$APT_DIR/opt/datadog-agent/embedded/lib:$APT_DIR/usr/
 # Set Datadog configs
 export DD_LOG_FILE="$DD_LOG_DIR/datadog.log"
 DD_APM_LOG="$DD_LOG_DIR/datadog-apm.log"
+DD_PROC_LOG="$DD_LOG_DIR/datadog-proc.log"
 
 # Move Datadog config files into place
 cp "$DATADOG_CONF.example" "$DATADOG_CONF"
@@ -70,6 +71,7 @@ sed -i -e"s|^apm_config:$|apm_config:\n  log_file: $DD_APM_LOG|" "$DATADOG_CONF"
 # Uncomment the Process Agent configs and enable.
 if [ "$DD_PROCESS_AGENT" == "true" ]; then
   sed -i -e"s|^# process_config:$|process_config:\n  enabled: true|" "$DATADOG_CONF"
+  sed -i -e"s|^process_config:$|process_config:\n  log_file: $DD_PROC_LOG|" "$DATADOG_CONF"
 fi
 
 # Set the right path for the log collector

--- a/test/compile_and_run_test.sh
+++ b/test/compile_and_run_test.sh
@@ -2,6 +2,7 @@
 
 . ${BUILDPACK_TEST_RUNNER_HOME}/lib/test_utils.sh
 
+export DD_LOG_LEVEL="debug"
 
 getAvailableVersions()
 {


### PR DESCRIPTION
Fixes #23 #20 

The process team finally implemented the changes required to honour the DD_LOG_LEVEL parameter, so log levels are now fully manageable.

Also, we now set the process_agent: log_file parameter, so the agent doesn't try to create a file in a non-writable folder.