### PR TITLE
fix(agent-wrapper): allow to pass multiple command

### DIFF
--- a/extra/agent-wrapper
+++ b/extra/agent-wrapper
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
-# Run the Datadog Agent with the selected command 
-bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_BIN_DIR/agent -c $DATADOG_CONF "$@" "
+# Run the Datadog Agent with the selected command
+export PYTHONPATH="$DD_PYTHONPATH"
+export LD_LIBRARY_PATH="$DD_LD_LIBRARY_PATH"
+exec "$DD_BIN_DIR"/agent -c "$DATADOG_CONF" $*


### PR DESCRIPTION
Running `agent-wrapper check foobar` does not work currently and only print
help.