### PR TITLE
Reduce buildpack size

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -155,6 +155,10 @@ done
 
 # Remove the system-probe binary, only needed for network performance monitoring
 rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/system-probe"
+rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/libbcc*
+
+# Remove the Security agent
+rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/security-agent"
 
 if [ -f "$ENV_DIR/DD_APM_ENABLED" ]; then
   DD_APM_ENABLED=$(cat "$ENV_DIR/DD_APM_ENABLED")

--- a/test/compile_and_run_test.sh
+++ b/test/compile_and_run_test.sh
@@ -47,7 +47,11 @@ compileAndRunVersion()
   SIZE_LIB=$(du -s  $HOME/.apt/opt/datadog-agent/embedded/lib | cut -f1)
   SIZE_EMB_BIN=$(du -s  $HOME/.apt/opt/datadog-agent/embedded/bin | cut -f1)
 
-  assertTrue "Binary folder is too big: ${SIZE_BIN}" "[ $SIZE_BIN -lt 105000 ]"
+  # Prior to 6.13 the agent was too big
+  BIGSIZE_VERSION="6.13.0-1"
+  if test "$BIGSIZE_VERSION" = "$(echo "$BIGSIZE_VERSION\n$1" | sort -V | head -n1)" ; then
+    assertTrue "Binary folder is too big: ${SIZE_BIN}" "[ $SIZE_BIN -lt 105000 ]"
+  fi
   assertTrue "Embedded library folder is too big: ${SIZE_LIB}" "[ $SIZE_LIB -lt 230000 ]"
   assertTrue "Embedded binary folder is too big: ${SIZE_EMB_BIN}" "[ $SIZE_EMB_BIN -lt 115000 ]"
 

--- a/test/compile_and_run_test.sh
+++ b/test/compile_and_run_test.sh
@@ -21,6 +21,7 @@ compileAndRunVersion()
 {
 
   echo $1 > "${ENV_DIR}/DD_AGENT_VERSION"
+  echo "true" > "${ENV_DIR}/DD_PROCESS_AGENT"
   echo "Testing Datadog Agent version $1"
   compile
   assertCaptured "Installing dependencies"
@@ -41,6 +42,16 @@ compileAndRunVersion()
   assertNotCaptured "ModuleNotFoundError"
   assertNotCaptured "Fatal Python error"
 
+  
+  SIZE_BIN=$(du -s  $HOME/.apt/opt/datadog-agent/bin | cut -f1)
+  SIZE_LIB=$(du -s  $HOME/.apt/opt/datadog-agent/embedded/lib | cut -f1)
+  SIZE_EMB_BIN=$(du -s  $HOME/.apt/opt/datadog-agent/embedded/bin | cut -f1)
+
+  assertTrue "Binary folder is too big: ${SIZE_BIN}" "[ $SIZE_BIN -lt 105000 ]"
+  assertTrue "Embedded library folder is too big: ${SIZE_LIB}" "[ $SIZE_LIB -lt 230000 ]"
+  assertTrue "Embedded binary folder is too big: ${SIZE_EMB_BIN}" "[ $SIZE_EMB_BIN -lt 115000 ]"
+
+  rm -rf $HOME/.apt/
 }
 
 testReleased6Versions()
@@ -49,7 +60,7 @@ testReleased6Versions()
 
   for VERSION in ${AGENT_VERSIONS}; do
     compileAndRunVersion $VERSION
-  done 
+  done
 }
 
 testReleased7Versions()


### PR DESCRIPTION
Fixes #204 

This PR removes system-probe dependencies and the security-agent, as those are not needed in Heroku.
It also adds some tests that will warn in the case of a sudden increase in the buildpack size.