### PR TITLE
Fix the log_config.run_path even if logs are not enabled

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -64,10 +64,8 @@ if [ "$DD_PROCESS_AGENT" == "true" ]; then
 fi
 
 # Set the right path for the log collector
-if [ "$DD_LOGS_ENABLED" == "true" ]; then
-  sed -i -e"s|^# logs_config:$|logs_config:|" "$DATADOG_CONF"
-  sed -i -e"s|^logs_config:$|logs_config:\n  run_path: $DD_RUN_DIR|" "$DATADOG_CONF"
-fi
+sed -i -e"s|^# logs_config:$|logs_config:|" "$DATADOG_CONF"
+sed -i -e"s|^logs_config:$|logs_config:\n  run_path: $DD_RUN_DIR|" "$DATADOG_CONF"
 
 # For a list of env vars to override datadog.yaml, see:
 # https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config.go#L145


### PR DESCRIPTION
Fixes #205

The log_config.run_path parameter is now used to write a a new file (versionHistory.json) that is not directly related to logs. 

This PR removes the need of DD_LOGS_ENABLED to be true to set the right path, to be able to create this file in the right path