### PR TITLE
Change buildpack detection name from "Sysstat" to "Datadog"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased & outstanding issues]
 - Non-https repo url and apt fetching
+- Buildpack name reported by `bin/detect` is now "Datadog" instead of "Sysstat"
 
 ## [1.20] - 2020-09-09
 

--- a/bin/detect
+++ b/bin/detect
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-echo "Sysstat" && exit 0
+echo "Datadog" && exit 0


### PR DESCRIPTION
Hi! Whilst I was debugging a customer support ticket, it was confusing to see a buildpack called "Sysstat" in the build log output, which did not appear to match any of the buildpacks in the buildpacks URLs list for that app.

The buildpack is for Datadog, so calling it that seems more intuitive, plus it then matches the GitHub repo URL that appears in the buildpacks URLs list.

See:
https://devcenter.heroku.com/articles/buildpack-api#bin-detect

Example build log before:

```
-----> Deleting 1 files matching .slugignore patterns.
-----> Sysstat app detected
-----> Updating apt caches for dependencies
...
-----> Ruby app detected
...
```

Example build log after:

```
-----> Deleting 1 files matching .slugignore patterns.
-----> Datadog app detected
-----> Updating apt caches for dependencies
...
-----> Ruby app detected
...
```