### PR TITLE
Update Agent GPG keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,9 +222,10 @@ As an example, if you are building your Docker image using a Debian based OS, yo
 RUN apt-get update \
  && apt-get install -y gpg apt-transport-https gpg-agent curl ca-certificates
 
-# Add Datadog repository and signing key
+# Add Datadog repository and signing keys
 RUN sh -c "echo 'deb https://apt.datadoghq.com/ stable 7' > /etc/apt/sources.list.d/datadog.list"
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
+RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 D75CEA17048B9ACBF186794B32637D44F14F620E
 
 # Install the Datadog agent
 RUN apt-get update && apt-get -y --force-yes install --reinstall datadog-agent


### PR DESCRIPTION
### What does this PR do?

Updates the GPG signing keys for the Datadog Agent apt repository.

### Motivation

Prepare future GPG key rotation.