### PR TITLE
Disable cloud provider metadata

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -30,6 +30,9 @@ cp "$DATADOG_CONF.example" "$DATADOG_CONF"
 sed -i -e"s|^.*confd_path:.*$|confd_path: $DD_CONF_DIR/conf.d|" "$DATADOG_CONF"
 sed -i -e"s|^.*additional_checksd:.*$|additional_checksd: $DD_CONF_DIR/checks.d\nrun_path: $DD_RUN_DIR|" "$DATADOG_CONF"
 
+# Update the Datadog conf yaml to disable cloud provider metadata
+sed -i -e"s|^.*cloud_provider_metadata:.*$|cloud_provider_metadata: []|" "$DATADOG_CONF"
+
 # Include application's datadog configs
 APP_DATADOG="/app/datadog"
 APP_DATADOG_CONF_DIR="$APP_DATADOG/conf.d"


### PR DESCRIPTION
Disable cloud provider metadata, that doesn't make sense in a Heroku environment, and was giving users weird warnings in the logs.

Fixes https://github.com/DataDog/datadog-agent/issues/6583