### PR TITLE
Clean the APT state dir between versions and stacks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -80,6 +80,7 @@ else
   # STACK or DD_AGENT_VERSION changed, clean up APT cache
   topic "Detected Stack and/or agent version changes, flushing cache"
   rm -rf $APT_CACHE_DIR
+  rm -rf $APT_STATE_DIR
   mkdir -p "$APT_CACHE_DIR/archives/partial"
   mkdir -p "$APT_STATE_DIR/lists/partial"
 fi


### PR DESCRIPTION
This cleans the apt state when cleaning the cache, avoiding some instances of issues similar to #254 (although those type of issues can be manually fixed cleaning up the build cache if needed)