### PR TITLE
Fix memcached integration for Python 3

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -142,12 +142,10 @@ DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR/lib-tk:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR/lib-dynload:$DD_PYTHONPATH"
 DD_PYTHONPATH="$DD_DIR/bin/agent/dist:$DD_PYTHONPATH"
 
-# For Python2 we need to add explicitely pip and setuptools dependencies
-if [ "$DD_PYTHON_VERSION" = "2" ]; then
-  PIP_PATH=$(find "$DD_DIR/embedded/lib/$PYTHON_DIR/site-packages" -maxdepth 1 -name "pip*egg")
-  SETUPTOOLS_PATH=$(find "$DD_DIR/embedded/lib/$PYTHON_DIR/site-packages" -maxdepth 1 -name "setuptools*egg")
-  DD_PYTHONPATH="$DD_PYTHONPATH:$SETUPTOOLS_PATH:$PIP_PATH"
-fi
+#  We need to add explicitely pip and setuptools dependencies
+PIP_PATH=$(find "$DD_DIR/embedded/lib/$PYTHON_DIR/site-packages" -maxdepth 1 -name "pip*egg")
+SETUPTOOLS_PATH=$(find "$DD_DIR/embedded/lib/$PYTHON_DIR/site-packages" -maxdepth 1 -name "setuptools*egg")
+DD_PYTHONPATH="$DD_PYTHONPATH:$SETUPTOOLS_PATH:$PIP_PATH"
 
 # Export agent's PYTHONPATH be used by the agent-wrapper
 export DD_PYTHONPATH="$DD_DIR/embedded/lib:$DD_PYTHONPATH"

--- a/test/compile_and_run_test.sh
+++ b/test/compile_and_run_test.sh
@@ -51,7 +51,7 @@ compileAndRunVersion()
   if test "$BIGSIZE_VERSION" = "$(echo "$BIGSIZE_VERSION\n$1" | sort -V | head -n1)" ; then
     assertTrue "Binary folder is too big: ${SIZE_BIN}" "[ $SIZE_BIN -lt 105000 ]"
   fi
-  assertTrue "Embedded library folder is too big: ${SIZE_LIB}" "[ $SIZE_LIB -lt 230000 ]"
+  assertTrue "Embedded library folder is too big: ${SIZE_LIB}" "[ $SIZE_LIB -lt 255000 ]"
   assertTrue "Embedded binary folder is too big: ${SIZE_EMB_BIN}" "[ $SIZE_EMB_BIN -lt 115000 ]"
 
   rm -rf $HOME/.apt/


### PR DESCRIPTION
Starting with `7.28.0` we no longer ship `pip` or `setuptools` with the Python 3 distribution shipped with the agent (related change: https://github.com/DataDog/datadog-agent/pull/7681), so we need to add explicitly the ones shipped by the integrations team to the `PYTHONPATH` of the agent.

A second commit for this PR fixes a failing test due to an increase of size of the library folder.