### PR TITLE
Pin versions 6.30 and 7.30

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,8 +11,8 @@ set -o pipefail
 # set -x
 
 # Set agent pinned version
-DD_AGENT_PINNED_VERSION_6="6.29.0-1"
-DD_AGENT_PINNED_VERSION_7="7.29.0-1"
+DD_AGENT_PINNED_VERSION_6="6.30.0-1"
+DD_AGENT_PINNED_VERSION_7="7.30.0-1"
 
 # Parse and derive params
 BUILD_DIR=$1


### PR DESCRIPTION
Pin 6.30 and 7.30 as the new default agent versions for the buildpack