### PR TITLE
Pin version 7.31 

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -186,6 +186,9 @@ done
 rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/system-probe"
 rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/libbcc*
 
+# Remove static libraries
+rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/*.a
+
 # Remove the Security agent
 rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/security-agent"
 

--- a/bin/compile
+++ b/bin/compile
@@ -11,8 +11,8 @@ set -o pipefail
 # set -x
 
 # Set agent pinned version
-DD_AGENT_PINNED_VERSION_6="6.29.0-1"
-DD_AGENT_PINNED_VERSION_7="7.29.0-1"
+DD_AGENT_PINNED_VERSION_6="6.31.0-1"
+DD_AGENT_PINNED_VERSION_7="7.31.0-1"
 
 # Parse and derive params
 BUILD_DIR=$1


### PR DESCRIPTION
This PR updates the buildpack to pin 7.31 by default and in the process removes some unnecessary static libraries