### PR TITLE
Prepare release 1.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased & outstanding issues]
 - The `process-agent` increased in size between 7.31 and 7.32. We are aware the increasing slug size with this buildpack presents issues for some users, and we are working on providing a long term solution. For updates on this you can follow [issue 269 in Github](https://github.com/DataDog/heroku-buildpack-datadog/issues/269)
 
+## [1.32] - 2021-12-23
+
+### Security
+
+- Agents `6.32.4` and `7.33.4` remove all dependencies on log4j and use java.util.logging instead.
+
+### Added
+- Datadog agent pinned versions are now `6.32.4` and `7.32.4`
+
 ## [1.31] - 2021-12-16
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased & outstanding issues]
 - The `process-agent` increased in size between 7.31 and 7.32. We are aware the increasing slug size with this buildpack presents issues for some users, and we are working on providing a long term solution. For updates on this you can follow [issue 269 in Github](https://github.com/DataDog/heroku-buildpack-datadog/issues/269)
 
-## [1.32] - 2021-12-23
+## [1.32] - 2021-12-27
 
 ### Security
 

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -50,7 +50,7 @@ done
 # Add tags to the config file
 DYNOHOST="$(hostname )"
 DYNOTYPE=${DYNO%%.*}
-BUILDPACKVERSION="dev"
+BUILDPACKVERSION="1.32"
 DYNO_TAGS="dyno:$DYNO dynotype:$DYNOTYPE buildpackversion:$BUILDPACKVERSION"
 
 # We want always to have the Dyno ID as a host alias to improve correlation


### PR DESCRIPTION
Prepare release 1.32 - Datadog agent pinned versions are now `6.32.4` and `7.32.4`