### PR TITLE
Add ability and documentation on enabling custom checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ agent-wrapper integration install -t datadog-ping==1.0.0
 
 ## Enabling custom checks
 
-To enable your own [Agent Custom Checks][29], create a `checks.d` folder in the datadog configuration folder within your application. Under it, copy all `.py` and `.yaml` files from your custom checks. During the dyno start up, your files are copied to the appropriate Datadog Agent configuration directories.
+To enable your own [Agent Custom Checks][22], create a `checks.d` folder in the datadog configuration folder within your application. Under it, copy all `.py` and `.yaml` files from your custom checks. During the dyno start up, your files are copied to the appropriate Datadog Agent configuration directories.
 
 For example, if you have two custom checks, `foo` and `bar`, this would be the right folder tree:
 
@@ -258,7 +258,7 @@ To reduce your slug size, make sure that `DD_APM_ENABLED` is set to `false`, if 
 
 ## Debugging
 
-To run any of the [information or debugging commands][22], use the `agent-wrapper` command.
+To run any of the [information or debugging commands][23], use the `agent-wrapper` command.
 
 For example, to display the status of your Datadog Agent and enabled integrations, run:
 
@@ -278,7 +278,7 @@ The Datadog buildpack does not collect logs from the Heroku platform. To set up 
 
 ## Using Heroku with Docker images
 
-This buildpack only works for Heroku deployments that use [Heroku's Slug Compiler][23]. If you are deploying your application in Heroku using Docker containers, add the Datadog Agent as part of your Docker image and start the Agent as a different process in your container.
+This buildpack only works for Heroku deployments that use [Heroku's Slug Compiler][24]. If you are deploying your application in Heroku using Docker containers, add the Datadog Agent as part of your Docker image and start the Agent as a different process in your container.
 
 As an example, if you are building your Docker image using a Debian based OS, add the following lines to your `Dockerfile`:
 
@@ -325,15 +325,15 @@ datadog-agent run &
 /opt/datadog-agent/embedded/bin/process-agent --config=/etc/datadog-agent/datadog.yaml
 ```
 
-For more advanced options in the Docker image, reference the [Datadog Agent Docker files][24].
+For more advanced options in the Docker image, reference the [Datadog Agent Docker files][25].
 
 ## Contributing
 
-See the [contributing guidelines][25] to learn how to open an issue or PR to the [Heroku-buildpack-datadog repository][26].
+See the [contributing guidelines][26] to learn how to open an issue or PR to the [Heroku-buildpack-datadog repository][27].
 
 ## History
 
-Earlier versions of this project were forked from the [miketheman heroku-buildpack-datadog project][27]. It was largely rewritten for Datadog's Agent version 6. Changes and more information can be found in the [changelog][28].
+Earlier versions of this project were forked from the [miketheman heroku-buildpack-datadog project][28]. It was largely rewritten for Datadog's Agent version 6. Changes and more information can be found in the [changelog][29].
 
 ## Troubleshooting
 
@@ -475,11 +475,11 @@ After an upgrade of the buildpack or Agent, you must recompile your application'
 [19]: https://github.com/DataDog/integrations-core/blob/master/redisdb/datadog_checks/redisdb/data/conf.yaml.example
 [20]: https://github.com/DataDog/integrations-extras/
 [21]: https://github.com/DataDog/integrations-extras/tree/master/ping
-[22]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[23]: https://devcenter.heroku.com/articles/slug-compiler
-[24]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles
-[25]: https://github.com/DataDog/heroku-buildpack-datadog/blob/master/CONTRIBUTING.md
-[26]: https://github.com/DataDog/heroku-buildpack-datadog
-[27]: https://github.com/miketheman/heroku-buildpack-datadog
-[28]: https://github.com/DataDog/heroku-buildpack-datadog/blob/master/CHANGELOG.md
-[29]: https://docs.datadoghq.com/developers/custom_checks/
+[22]: https://docs.datadoghq.com/developers/custom_checks/
+[23]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[24]: https://devcenter.heroku.com/articles/slug-compiler
+[25]: https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles
+[26]: https://github.com/DataDog/heroku-buildpack-datadog/blob/master/CONTRIBUTING.md
+[27]: https://github.com/DataDog/heroku-buildpack-datadog
+[28]: https://github.com/miketheman/heroku-buildpack-datadog
+[29]: https://github.com/DataDog/heroku-buildpack-datadog/blob/master/CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -188,6 +188,23 @@ For example, to install the [ping integration][21], create the configuration fil
 agent-wrapper integration install -t datadog-ping==1.0.0
 ```
 
+## Enabling custom checks
+
+To enable your own [Agent Custom Checks][29], create a `checks.d` folder in the datadog configuration folder within your application. Under it, copy all `.py` and `.yaml` files from your custom checks. During the dyno start up, your files are copied to the appropriate Datadog Agent configuration directories.
+
+For example, if you have two custom checks, `foo` and `bar`, this would be the right folder tree:
+
+```
+.
+└── app
+    └── datadog
+        └── checks.d
+            ├── foo.py
+            ├── foo.yaml
+            ├── bar.py
+            └── bar.yaml
+```
+
 ## Prerun script
 
 In addition to all of the configurations above, you can include a prerun script, `/datadog/prerun.sh`, in your application. The prerun script runs after all of the standard configuration actions and immediately before starting the Datadog Agent. This allows you to modify the environment variables (for example: DD_TAGS or DD_VERSION), perform additional configurations, install community integrations, or even disable the Datadog Agent programmatically.
@@ -465,3 +482,4 @@ After an upgrade of the buildpack or Agent, you must recompile your application'
 [26]: https://github.com/DataDog/heroku-buildpack-datadog
 [27]: https://github.com/miketheman/heroku-buildpack-datadog
 [28]: https://github.com/DataDog/heroku-buildpack-datadog/blob/master/CHANGELOG.md
+[29]: https://docs.datadoghq.com/developers/custom_checks/

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -38,13 +38,27 @@ sed -i -e"s|^.*cloud_provider_metadata:.*$|cloud_provider_metadata: []|" "$DATAD
 APP_DATADOG_DEFAULT="/app/datadog"
 APP_DATADOG="${DD_HEROKU_CONF_FOLDER:=$APP_DATADOG_DEFAULT}"
 APP_DATADOG_CONF_DIR="$APP_DATADOG/conf.d"
+APP_DATADOG_CHECKS_DIR="$APP_DATADOG/checks.d"
 
+# Agent integrations configuration
 for file in "$APP_DATADOG_CONF_DIR"/*.yaml; do
   test -e "$file" || continue # avoid errors when glob doesn't match anything
   filename="$(basename -- "$file")"
   filename="${filename%.*}"
   mkdir -p "$DD_CONF_DIR/conf.d/${filename}.d"
   cp "$file" "$DD_CONF_DIR/conf.d/${filename}.d/conf.yaml"
+done
+
+# Custom checks configuration
+for file in "$APP_DATADOG_CHECKS_DIR"/*.yaml; do
+  test -e "$file" || continue # avoid errors when glob doesn't match anything
+  cp "$file" "$DD_CONF_DIR/conf.d/"
+done
+
+# Custom checks code
+for file in "$APP_DATADOG_CHECKS_DIR"/*.py; do
+  test -e "$file" || continue # avoid errors when glob doesn't match anything
+  cp "$file" "$DD_CONF_DIR/checks.d/"
 done
 
 # Add tags to the config file


### PR DESCRIPTION
Fixes #276 #175 

Enabling custom checks is not straight forward when using this buildpack.

This PR enables doing this from the `/datadog` folder, and adds documentation about it.