### PR TITLE
Fix hardcoded python symlinks

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -139,12 +139,12 @@ if [ "$DD_PYTHON_VERSION" = "3" ]; then
   if [ "$DD_AGENT_VERSION" != "$(echo -e "$DD_AGENT_BASE_VERSION\n$DD_AGENT_VERSION" | sort -V | head -n1)" ]; then
     # If Python version is 3, it has to be specified in the configuration file
     echo 'python_version: 3' >> $DATADOG_CONF
+  fi
     # Update symlinks to Python binaries
     ln -sfn "$DD_DIR"/embedded/bin/python3 "$DD_DIR"/embedded/bin/python
     ln -sfn "$DD_DIR"/embedded/bin/python3-config "$DD_DIR"/embedded/bin/python-config
     ln -sfn "$DD_DIR"/embedded/bin/pip3 "$DD_DIR"/embedded/bin/pip
     ln -sfn "$DD_DIR"/embedded/bin/pydoc3 "$DD_DIR"/embedded/bin/pydoc
-  fi
 fi
 
 # Ensure all check and library locations are findable in the Python path.


### PR DESCRIPTION
There are some hardcoded python symlinks in the agent that don't work for Heroku, and make installing community integrations fail in some cases.

This PR forces rewriting the symlinks to avoid this