### PR TITLE
Only test for size starting on agent 7.34/6.34

### DIFF
--- a/test/compile_and_run_test.sh
+++ b/test/compile_and_run_test.sh
@@ -46,13 +46,11 @@ compileAndRunVersion()
   SIZE_LIB=$(du -s  $HOME/.apt/opt/datadog-agent/embedded/lib | cut -f1)
   SIZE_EMB_BIN=$(du -s  $HOME/.apt/opt/datadog-agent/embedded/bin | cut -f1)
 
-  # Prior to 6.13 the agent was too big
-  BIGSIZE_VERSION="6.13.0-1"
-  if test "$BIGSIZE_VERSION" = "$(echo "$BIGSIZE_VERSION\n$1" | sort -V | head -n1)" ; then
-    assertTrue "Binary folder is too big: ${SIZE_BIN}" "[ $SIZE_BIN -lt 105000 ]"
+  if $2; then
+    assertTrue "Binary folder is too big: ${SIZE_BIN}" "[ $SIZE_BIN -lt 80000 ]"
+    assertTrue "Embedded library folder is too big: ${SIZE_LIB}" "[ $SIZE_LIB -lt 180000 ]"
+    assertTrue "Embedded binary folder is too big: ${SIZE_EMB_BIN}" "[ $SIZE_EMB_BIN -lt 80000 ]"
   fi
-  assertTrue "Embedded library folder is too big: ${SIZE_LIB}" "[ $SIZE_LIB -lt 255000 ]"
-  assertTrue "Embedded binary folder is too big: ${SIZE_EMB_BIN}" "[ $SIZE_EMB_BIN -lt 115000 ]"
 
   rm -rf $HOME/.apt/
 }
@@ -64,7 +62,12 @@ testReleased6Versions()
   echo "deb [signed-by=SIGNED_BY_PLACEHOLDER] https://apt.datadoghq.com/ stable 6" > "${BUILDPACK_HOME}/etc/datadog.list"
 
   for VERSION in ${AGENT_VERSIONS}; do
-    compileAndRunVersion $VERSION
+    # Only test for size from 6.34 onwards
+    if test "6.34.0-1" = "$(echo "6.34.0-1\n$VERSION" | sort -V | head -n1)" ; then
+      compileAndRunVersion $VERSION true
+    else
+      compileAndRunVersion $VERSION false
+    fi
   done
 }
 
@@ -75,7 +78,12 @@ testReleased7Versions()
   echo "deb [signed-by=SIGNED_BY_PLACEHOLDER] https://apt.datadoghq.com/ stable 7" > "${BUILDPACK_HOME}/etc/datadog7.list"
 
   for VERSION in ${AGENT_VERSIONS}; do
-    compileAndRunVersion $VERSION
+    # Only test for size from 7.34 onwards
+    if test "7.34.0-1" = "$(echo "7.34.0-1\n$VERSION" | sort -V | head -n1)" ; then
+      compileAndRunVersion $VERSION true
+    else
+      compileAndRunVersion $VERSION false
+    fi
   done
 }
 


### PR DESCRIPTION
With the new builds, the size of the buildpack has decreased and we should take that size as the baseline for our tests.

This PR fixes the tests by establishing that new baseline, and test for size only starting with 6.34/7.34 builds.