### PR TITLE
Fix conflict with apt buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -183,7 +183,8 @@ dpkg -x "$DEB" "$APT_DIR"
 rm -rf "$APT_DIR"/opt/datadog-agent/sources \
        "$APT_DIR"/opt/datadog-agent/embedded/share/doc \
        "$APT_DIR"/opt/datadog-agent/embedded/share/man \
-       "$APT_DIR"/opt/datadog-agent/embedded/.installed_by_pkg.txt
+       "$APT_DIR"/opt/datadog-agent/embedded/.installed_by_pkg.txt \
+       "$DEB"
 
 # Remove Cryptodome Selftest
 rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/python*/site-packages/Cryptodome/SelfTest


### PR DESCRIPTION
Fixes an issue that happens when this buildpack is used in conjunction with https://github.com/heroku/heroku-buildpack-apt that causes the Datadog package to be installed twice, thus increasing the slug size

*Steps to reproduce*

1. Create a slug with two buildpacks: https://github.com/heroku/heroku-buildpack-apt https://github.com/DataDog/heroku-buildpack-datadog
2. Trigger a build twice

*Expected results*

* The first build will not use cache since it does not exist yet
* The second build will use the cache
* In both cases, the slug size should be the same

*What really happens*

The second build produces a bigger slug than the first one

*Why?*

During the first build, the `heroku-buildpack-datadog` buildpack leaves behind a `.deb` file that it creates here:
https://github.com/DataDog/heroku-buildpack-datadog/blob/17e34c7a517f9ae6047175d46a1c5e64754641ef/bin/compile#L172-L176

During the second build, by the time that the `heroku-buildpack-apt` buildpack runs, it will install all the `.deb` packages in the cache causing the Datadog Agent to be installed again:
https://github.com/heroku/heroku-buildpack-apt/blob/0a778933873c3b4c4e5f046db41890ea609afb74/bin/compile#L98-L101

*Proposed fix*

Just remove the `.deb` file created by Datadog after the `dpkg` installation, since it is not used directly in the next cached run