### PR TITLE
Easily enable the Redis and Postgres integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,37 @@ In order to collect system metrics for your dynos, you must:
 
 ## Enabling integrations
 
-To enable a [Datadog-<INTEGRATION_NAME> integration][17]:
+### Enabling the Datadog Redis integration
+
+If you are using a Redis addon in your Heroku application (for example, Heroku Data for Redis or Redis Enterprise Cloud), you can easily enable the Datadog Redis integration by setting an envionment variable:
+
+```
+heroku config:set ENABLE_HEROKU_REDIS=true
+```
+
+By default, this integration assumes the Redis connection URL is defined in an environement variable called `REDIS_URL` (this is default for Heroku Data for Redis and other addons).
+
+If your connection URL is defined in a different environment variable, set the `REDIS_URL_VAR` environment variable to the name of the variable name. For example, if you're using Redis Enterprise Cloud, set it to "REDISCLOUD_URL":
+
+```
+heroku config:set REDIS_URL_VAR=REDISCLOUD_URL
+```
+
+### Enabling the Datadog Postgres integration
+
+If you are using a Postgres addon in your Heroku application (for example, Heroku Postgres), you can easily enable the Datadog Postgres integration by setting an envionment variable:
+
+```
+heroku config:set ENABLE_HEROKU_POSTGRES=true
+```
+
+By default, this integration assumes the Postgres connection URL is defined in an environement variable called `DATABASE_URL` (this is default for Heroku Postgres and other addons).
+
+If your connection URL is defined in a different environment variable, set the `POSTGRES_URL_VAR` environment variable to the name of the variable name.
+
+### Enabling other integrations
+
+To enable any [Datadog-<INTEGRATION_NAME> integration][17]:
 
 * Create a `datadog/conf.d` folder within your application.
 * For each integration to enable, create an `<INTEGRATION_NAME>.d` folder
@@ -162,25 +192,19 @@ To enable a [Datadog-<INTEGRATION_NAME> integration][17]:
 
 During the dyno start up, your YAML files are copied to the appropriate Datadog Agent configuration directories.
 
-For example, to enable the [Datadog-Redis integration][19], add the file `/datadog/conf.d/redisdb.d/conf.yaml` at the root of your application (or `/$DD_HEROKU_CONF_FOLDER/conf.d/redisdb.d/conf.yaml` if you have changed this [configuration option](#configuration)):
+For example, to enable the [Datadog-Memcache integration][19], add the file `/datadog/conf.d/mcache.d/conf.yaml` at the root of your application (or `/$DD_HEROKU_CONF_FOLDER/conf.d/mcache.d/conf.yaml` if you have changed this [configuration option](#configuration)):
 
 ```yaml
 init_config:
 
 instances:
-
-    ## @param host - string - required
-    ## Enter the host to connect to.
-    #
-  - host: <REDIS_HOST>
-
-    ## @param port - integer - required
-    ## Enter the port of the host to connect to.
-    #
-    port: 6379
+  ## @param url - string - required
+  ## url used to connect to the Memcached instance.
+  #
+  - url: localhost
 ```
 
-**Note**: See the sample [redisdb.d/conf.yaml][20] for all available configuration options.
+**Note**: See the sample [mcache.d/conf.yaml][20] for all available configuration options.
 
 ### Community Integrations
 
@@ -248,18 +272,6 @@ fi
 # Set app version based on HEROKU_SLUG_COMMIT
 if [ -n "$HEROKU_SLUG_COMMIT" ]; then
   DD_VERSION=$HEROKU_SLUG_COMMIT
-fi
-
-# Update the Postgres configuration from above using the Heroku application environment variable
-if [ -n "$DATABASE_URL" ]; then
-  POSTGREGEX='^postgres://([^:]+):([^@]+)@([^:]+):([^/]+)/(.*)$'
-  if [[ $DATABASE_URL =~ $POSTGREGEX ]]; then
-    sed -i "s/<YOUR HOSTNAME>/${BASH_REMATCH[3]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
-    sed -i "s/<YOUR USERNAME>/${BASH_REMATCH[1]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
-    sed -i "s/<YOUR PASSWORD>/${BASH_REMATCH[2]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
-    sed -i "s/<YOUR PORT>/${BASH_REMATCH[4]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
-    sed -i "s/<YOUR DBNAME>/${BASH_REMATCH[5]}/" "$DD_CONF_DIR/conf.d/postgres.d/conf.yaml"
-  fi
 fi
 
 # Install the "ping" community integration
@@ -505,8 +517,8 @@ After an upgrade of the buildpack or Agent, you must recompile your application'
 [16]: https://docs.datadoghq.com/logs/logs_to_metrics/
 [17]: https://docs.datadoghq.com/integrations/
 [18]: https://docs.datadoghq.com/getting_started/integrations/#configuring-agent-integrations
-[19]: https://docs.datadoghq.com/integrations/redisdb/
-[20]: https://github.com/DataDog/integrations-core/blob/master/redisdb/datadog_checks/redisdb/data/conf.yaml.example
+[19]: https://docs.datadoghq.com/integrations/mcache/
+[20]: https://github.com/DataDog/integrations-core/blob/master/mcache/datadog_checks/mcache/data/conf.yaml.example
 [21]: https://github.com/DataDog/integrations-extras/
 [22]: https://github.com/DataDog/integrations-extras/tree/master/ping
 [23]: https://docs.datadoghq.com/developers/custom_checks/

--- a/README.md
+++ b/README.md
@@ -156,15 +156,15 @@ In order to collect system metrics for your dynos, you must:
 
 ### Enabling the Datadog Redis integration
 
-If you are using a Redis addon in your Heroku application (for example, Heroku Data for Redis or Redis Enterprise Cloud), you can easily enable the Datadog Redis integration by setting an envionment variable:
+If you are using a Redis add-on in your Heroku application (for example, Heroku Data for Redis or Redis Enterprise Cloud), you can enable the Datadog Redis integration by setting an environment variable:
 
 ```
 heroku config:set ENABLE_HEROKU_REDIS=true
 ```
 
-By default, this integration assumes the Redis connection URL is defined in an environement variable called `REDIS_URL` (this is default for Heroku Data for Redis and other addons).
+By default, this integration assumes the Redis connection URL is defined in an environment variable called `REDIS_URL` (this is the default configuration for Heroku Data for Redis and other Redis add-ons).
 
-If your connection URL is defined in a different environment variable, set the `REDIS_URL_VAR` environment variable to the name of the variable name. For example, if you're using Redis Enterprise Cloud, set it to "REDISCLOUD_URL":
+If your connection URL is defined in a different environment variable, set the `REDIS_URL_VAR` environment variable to the variable name. For example, if you're using Redis Enterprise Cloud, set it to `REDISCLOUD_URL`:
 
 ```
 heroku config:set REDIS_URL_VAR=REDISCLOUD_URL
@@ -172,15 +172,15 @@ heroku config:set REDIS_URL_VAR=REDISCLOUD_URL
 
 ### Enabling the Datadog Postgres integration
 
-If you are using a Postgres addon in your Heroku application (for example, Heroku Postgres), you can easily enable the Datadog Postgres integration by setting an envionment variable:
+If you are using a Postgres add-on in your Heroku application (for example, Heroku Postgres), you can enable the Datadog Postgres integration by setting an environment variable:
 
 ```
 heroku config:set ENABLE_HEROKU_POSTGRES=true
 ```
 
-By default, this integration assumes the Postgres connection URL is defined in an environement variable called `DATABASE_URL` (this is default for Heroku Postgres and other addons).
+By default, this integration assumes the Postgres connection URL is defined in an environment variable called `DATABASE_URL` (this is the default configuration for Heroku Postgres and other Postgres add-ons).
 
-If your connection URL is defined in a different environment variable, set the `POSTGRES_URL_VAR` environment variable to the name of the variable name.
+If your connection URL is defined in a different environment variable, set the `POSTGRES_URL_VAR` environment variable to the variable name.
 
 ### Enabling other integrations
 

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -177,7 +177,7 @@ export DD_PYTHONPATH="$DD_DIR/embedded/lib:$DD_PYTHONPATH"
 
 # Update the Postgres configuration from above using the Heroku application environment variable
 if [ "$ENABLE_HEROKU_POSTGRES" == "true" ]; then
-  # The default connection URL is DATABASE_URL, but can be configured by the user
+  # The default connection URL is set in DATABASE_URL, but can be configured by the user
   if [[ -z ${POSTGRES_URL_VAR} ]]; then
     POSTGRES_URL_VAR="DATABASE_URL"
   fi
@@ -200,7 +200,7 @@ fi
 
 # Update the Redis configuration from above using the Heroku application environment variable
 if [ "$ENABLE_HEROKU_REDIS" == "true" ]; then
-  # The default connection URL is REDIS_URL, but can be configured by the user
+  # The default connection URL is set in REDIS_URL, but can be configured by the user
   if [[ -z ${REDIS_URL_VAR} ]]; then
     REDIS_URL_VAR="REDIS_URL"
   fi

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -177,7 +177,7 @@ export DD_PYTHONPATH="$DD_DIR/embedded/lib:$DD_PYTHONPATH"
 
 # Update the Postgres configuration from above using the Heroku application environment variable
 if [ "$ENABLE_HEROKU_POSTGRES" == "true" ]; then
-  # The connection URL is, by default DATABASE_URL, but can be configured by the user
+  # The default connection URL is DATABASE_URL, but can be configured by the user
   if [[ -z ${POSTGRES_URL_VAR} ]]; then
     POSTGRES_URL_VAR="DATABASE_URL"
   fi
@@ -200,7 +200,7 @@ fi
 
 # Update the Redis configuration from above using the Heroku application environment variable
 if [ "$ENABLE_HEROKU_REDIS" == "true" ]; then
-  # The connection URL is, by default REDIS_URL, but can be configured by the user
+  # The default connection URL is REDIS_URL, but can be configured by the user
   if [[ -z ${REDIS_URL_VAR} ]]; then
     REDIS_URL_VAR="REDIS_URL"
   fi

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -198,16 +198,18 @@ if [ "$ENABLE_HEROKU_REDIS" == "true" ]; then
 
   cp "$REDIS_CONF/conf.yaml.example" "$REDIS_CONF/conf.yaml"
 
-  if [ -n "$REDIS_TLS_URL" ]; then
-    REDISREGEX='^rediss://([^:]*):([^@]+)@([^:]+):(.+)$'
-    if [[ $REDIS_TLS_URL =~ $REDISREGEX ]]; then
-      sed -i "s/^  - host:.*/  - host: ${BASH_REMATCH[3]}/" "$REDIS_CONF/conf.yaml"
-      sed -i "s/^    # password:.*/    password: ${BASH_REMATCH[2]}/" "$REDIS_CONF/conf.yaml"
-      sed -i "s/^    port:.*/    port: ${BASH_REMATCH[4]}/" "$REDIS_CONF/conf.yaml"
-      sed -i "s/^    # ssl:.*/    ssl: True/" "$REDIS_CONF/conf.yaml"
-      sed -i "s/^    # ssl_cert_reqs:.*/    ssl_cert_reqs: 0/" "$REDIS_CONF/conf.yaml"
+  if [ -n "$REDIS_URL" ]; then
+    REDISREGEX='^redis(s?)://([^:]*):([^@]+)@([^:]+):(.+)$'
+    if [[ $REDIS_URL =~ $REDISREGEX ]]; then
+      sed -i "s/^  - host:.*/  - host: ${BASH_REMATCH[4]}/" "$REDIS_CONF/conf.yaml"
+      sed -i "s/^    # password:.*/    password: ${BASH_REMATCH[3]}/" "$REDIS_CONF/conf.yaml"
+      sed -i "s/^    port:.*/    port: ${BASH_REMATCH[5]}/" "$REDIS_CONF/conf.yaml"
       if [[ ! -z ${BASH_REMATCH[1]} ]]; then
-        sed -i "s/^#    username:.*/    username: ${BASH_REMATCH[1]}/" "$REDIS_CONF/conf.yaml"
+        sed -i "s/^    # ssl:.*/    ssl: True/" "$REDIS_CONF/conf.yaml"
+        sed -i "s/^    # ssl_cert_reqs:.*/    ssl_cert_reqs: 0/" "$REDIS_CONF/conf.yaml"
+      fi
+      if [[ ! -z ${BASH_REMATCH[2]} ]]; then
+        sed -i "s/^    # username:.*/    username: ${BASH_REMATCH[2]}/" "$REDIS_CONF/conf.yaml"
       fi
     fi
   fi

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -178,16 +178,15 @@ export DD_PYTHONPATH="$DD_DIR/embedded/lib:$DD_PYTHONPATH"
 # Update the Postgres configuration from above using the Heroku application environment variable
 if [ "$ENABLE_HEROKU_POSTGRES" == "true" ]; then
   # The connection URL is, by default DATABASE_URL, but can be configured by the user
-  DATABASE_URL="DATABASE_URL"
-  if [[ ! -z ${POSTGRES_URL_VAR} ]]; then
-    DATABASE_URL=${POSTGRES_URL_VAR}
+  if [[ -z ${POSTGRES_URL_VAR} ]]; then
+    POSTGRES_URL_VAR="DATABASE_URL"
   fi
 
   cp "$POSTGRES_CONF/conf.yaml.example" "$POSTGRES_CONF/conf.yaml"
 
-  if [ -n "${!DATABASE_URL}" ]; then
+  if [ -n "${!POSTGRES_URL_VAR}" ]; then
     POSTGREGEX='^postgres://([^:]+):([^@]+)@([^:]+):([^/]+)/(.*)$'
-    if [[ ${!DATABASE_URL} =~ $POSTGREGEX ]]; then
+    if [[ ${!POSTGRES_URL_VAR} =~ $POSTGREGEX ]]; then
       sed -i "s/^  - host:.*/  - host: ${BASH_REMATCH[3]}/" "$POSTGRES_CONF/conf.yaml"
       sed -i "s/^    username:.*/    username: ${BASH_REMATCH[1]}/" "$POSTGRES_CONF/conf.yaml"
       sed -i "s/^    # password:.*/    password: ${BASH_REMATCH[2]}/" "$POSTGRES_CONF/conf.yaml"
@@ -201,16 +200,15 @@ fi
 # Update the Redis configuration from above using the Heroku application environment variable
 if [ "$ENABLE_HEROKU_REDIS" == "true" ]; then
   # The connection URL is, by default REDIS_URL, but can be configured by the user
-  REDIS_URL="REDIS_URL"
-  if [[ ! -z ${REDIS_URL_VAR} ]]; then
-    REDIS_URL=${REDIS_URL_VAR}
+  if [[ -z ${REDIS_URL_VAR} ]]; then
+    REDIS_URL_VAR="REDIS_URL"
   fi
 
   cp "$REDIS_CONF/conf.yaml.example" "$REDIS_CONF/conf.yaml"
 
-  if [ -n "${!REDIS_URL}" ]; then
+  if [ -n "${!REDIS_URL_VAR}" ]; then
     REDISREGEX='^redis(s?)://([^:]*):([^@]+)@([^:]+):([^/]+)/?(.*)$'
-    if [[ ${!REDIS_URL} =~ $REDISREGEX ]]; then
+    if [[ ${!REDIS_URL_VAR} =~ $REDISREGEX ]]; then
       sed -i "s/^  - host:.*/  - host: ${BASH_REMATCH[4]}/" "$REDIS_CONF/conf.yaml"
       sed -i "s/^    # password:.*/    password: ${BASH_REMATCH[3]}/" "$REDIS_CONF/conf.yaml"
       sed -i "s/^    port:.*/    port: ${BASH_REMATCH[5]}/" "$REDIS_CONF/conf.yaml"

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -193,6 +193,26 @@ if [ "$ENABLE_HEROKU_POSTGRES" == "true" ]; then
   fi
 fi
 
+# Update the Redis configuration from above using the Heroku application environment variable
+if [ "$ENABLE_HEROKU_REDIS" == "true" ]; then
+
+  cp "$REDIS_CONF/conf.yaml.example" "$REDIS_CONF/conf.yaml"
+
+  if [ -n "$REDIS_TLS_URL" ]; then
+    REDISREGEX='^rediss://([^:]*):([^@]+)@([^:]+):(.+)$'
+    if [[ $REDIS_TLS_URL =~ $REDISREGEX ]]; then
+      sed -i "s/^  - host:.*/  - host: ${BASH_REMATCH[3]}/" "$REDIS_CONF/conf.yaml"
+      sed -i "s/^    # password:.*/    password: ${BASH_REMATCH[2]}/" "$REDIS_CONF/conf.yaml"
+      sed -i "s/^    port:.*/    port: ${BASH_REMATCH[4]}/" "$REDIS_CONF/conf.yaml"
+      sed -i "s/^    # ssl:.*/    ssl: True/" "$REDIS_CONF/conf.yaml"
+      sed -i "s/^    # ssl_cert_reqs:.*/    ssl_cert_reqs: 0/" "$REDIS_CONF/conf.yaml"
+      if [[ ! -z ${BASH_REMATCH[1]} ]]; then
+        sed -i "s/^#    username:.*/    username: ${BASH_REMATCH[1]}/" "$REDIS_CONF/conf.yaml"
+      fi
+    fi
+  fi
+fi
+
 # Give applications a chance to modify env vars prior to running.
 # Note that this can modify existing env vars or perform other actions (e.g. modify the conf file).
 # For more information on variables and other things you may wish to modify, reference this script

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -193,6 +193,7 @@ if [ "$ENABLE_HEROKU_POSTGRES" == "true" ]; then
       sed -i "s/^    # port:.*/    port: ${BASH_REMATCH[4]}/" "$POSTGRES_CONF/conf.yaml"
       sed -i "s/^    # dbname:.*/    dbname: ${BASH_REMATCH[5]}/" "$POSTGRES_CONF/conf.yaml"
       sed -i "s/^    # ssl:.*/    ssl: True/" "$POSTGRES_CONF/conf.yaml"
+      sed -i "s/^    disable_generic_tags:.*/    disable_generic_tags: false/" "$POSTGRES_CONF/conf.yaml"
     fi
   fi
 fi

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -195,12 +195,17 @@ fi
 
 # Update the Redis configuration from above using the Heroku application environment variable
 if [ "$ENABLE_HEROKU_REDIS" == "true" ]; then
+  # The connection URL is, by default REDIS_URL, but can be configured by the user
+  REDIS_URL="REDIS_URL"
+  if [[ ! -z ${REDIS_URL_VAR} ]]; then
+    REDIS_URL=${REDIS_URL_VAR}
+  fi
 
   cp "$REDIS_CONF/conf.yaml.example" "$REDIS_CONF/conf.yaml"
 
-  if [ -n "$REDIS_URL" ]; then
-    REDISREGEX='^redis(s?)://([^:]*):([^@]+)@([^:]+):(.+)$'
-    if [[ $REDIS_URL =~ $REDISREGEX ]]; then
+  if [ -n "${!REDIS_URL}" ]; then
+    REDISREGEX='^redis(s?)://([^:]*):([^@]+)@([^:]+):([^/]+)/?(.*)$'
+    if [[ ${!REDIS_URL} =~ $REDISREGEX ]]; then
       sed -i "s/^  - host:.*/  - host: ${BASH_REMATCH[4]}/" "$REDIS_CONF/conf.yaml"
       sed -i "s/^    # password:.*/    password: ${BASH_REMATCH[3]}/" "$REDIS_CONF/conf.yaml"
       sed -i "s/^    port:.*/    port: ${BASH_REMATCH[5]}/" "$REDIS_CONF/conf.yaml"
@@ -210,6 +215,9 @@ if [ "$ENABLE_HEROKU_REDIS" == "true" ]; then
       fi
       if [[ ! -z ${BASH_REMATCH[2]} ]]; then
         sed -i "s/^    # username:.*/    username: ${BASH_REMATCH[2]}/" "$REDIS_CONF/conf.yaml"
+      fi
+      if [[ ! -z ${BASH_REMATCH[6]} ]]; then
+        sed -i "s/^    # db:.*/    db: ${BASH_REMATCH[6]}/" "$REDIS_CONF/conf.yaml"
       fi
     fi
   fi

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -177,12 +177,17 @@ export DD_PYTHONPATH="$DD_DIR/embedded/lib:$DD_PYTHONPATH"
 
 # Update the Postgres configuration from above using the Heroku application environment variable
 if [ "$ENABLE_HEROKU_POSTGRES" == "true" ]; then
+  # The connection URL is, by default DATABASE_URL, but can be configured by the user
+  DATABASE_URL="DATABASE_URL"
+  if [[ ! -z ${POSTGRES_URL_VAR} ]]; then
+    DATABASE_URL=${POSTGRES_URL_VAR}
+  fi
 
   cp "$POSTGRES_CONF/conf.yaml.example" "$POSTGRES_CONF/conf.yaml"
 
-  if [ -n "$DATABASE_URL" ]; then
+  if [ -n "${!DATABASE_URL}" ]; then
     POSTGREGEX='^postgres://([^:]+):([^@]+)@([^:]+):([^/]+)/(.*)$'
-    if [[ $DATABASE_URL =~ $POSTGREGEX ]]; then
+    if [[ ${!DATABASE_URL} =~ $POSTGREGEX ]]; then
       sed -i "s/^  - host:.*/  - host: ${BASH_REMATCH[3]}/" "$POSTGRES_CONF/conf.yaml"
       sed -i "s/^    username:.*/    username: ${BASH_REMATCH[1]}/" "$POSTGRES_CONF/conf.yaml"
       sed -i "s/^    # password:.*/    password: ${BASH_REMATCH[2]}/" "$POSTGRES_CONF/conf.yaml"


### PR DESCRIPTION
Redis and Postgres are two integrations that are very popular in Heroku applications.

Datadog Heroku buildpack users usually need to configure these integrations by maintaining long prerun scripts.

This feature enables these integrations and configure them with their basic options by just setting an environment variable in the Heroku applications.