### PR TITLE
Allow multiple Redis/Postgres instances for auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ In addition to the environment variables shown above, there are several others y
 | `DD_DISABLE_HOST_METRICS`  | *Optional.* By default, the buildpack reports system metrics for the host machine running the dyno. Set this to `true` to disable system metrics collection. See the [system metrics section](#system-metrics) below for more information.                                                                                                                                                                                                                                                                                  |
 | `DD_PYTHON_VERSION`        | *Optional.* Starting with version `6.14.0`, Datadog Agent ships with Python versions `2` and `3`. The buildpack only keeps one of the versions. Set this to `2` or `3` to select the Python version you want the Agent to keep. If not set, the buildpack keeps `2`. Check the [Python versions section](#python-and-agent-versions) for more information. Changing this option requires recompiling the slug. Check [the upgrading and slug recompilation section](#upgrading-and-slug-recompilation) for details. |
 | `DD_HEROKU_CONF_FOLDER`    | *Optional.* By default, the buildpack looks in the root of your application for a folder `/datadog` for any configuration files you wish to include, see [prerun.sh script](#prerun-script). This location can be overridden by setting this to your desired path. |
+| `ENABLE_HEROKU_REDIS`    | *Optional.* Set it to true to enable Redis integration auto-discovery. Check [the Enabling the Datadog Redis Integration section](#enabling-the-datadog-redis-integration) for details. |
+| `REDIS_URL_VAR`    | *Optional.* By default, Redis integration auto-discovery uses the connection string stored at `REDIS_URL`, to override it, set this variable to a comma-separated list of variable names storing the connection strings. Check [the Enabling the Datadog Redis Integration section](#enabling-the-datadog-redis-integration) for details. |
+| `ENABLE_HEROKU_POSTGRES`    | *Optional.* Set it to true to enable Postgres integration auto-discovery. Check [the Enabling the Datadog Postgres Integration section](#enabling-the-datadog-postgres-integration) for details. |
+| `POSTGRES_URL_VAR`    | *Optional.* By default, Postgres integration auto-discovery uses the connection string stored at `DATABASE_URL`, to override it, set this variable to a comma-separated list of variable names storing the connection strings. Check [the Enabling the Datadog Postgres Integration section](#enabling-the-datadog-postgres-integration) for details. |
 
 For additional documentation, see the [Datadog Agent documentation][12].
 
@@ -164,10 +168,10 @@ heroku config:set ENABLE_HEROKU_REDIS=true
 
 By default, this integration assumes the Redis connection URL is defined in an environment variable called `REDIS_URL` (this is the default configuration for Heroku Data for Redis and other Redis add-ons).
 
-If your connection URL is defined in a different environment variable, set the `REDIS_URL_VAR` environment variable to the variable name. For example, if you're using Redis Enterprise Cloud, set it to `REDISCLOUD_URL`:
+If your connection URL is defined in a different environment variable, or you want to configure more than 1 Redis instance, set the `REDIS_URL_VAR` environment variable to the comma-separated variable names of your connection strings. For example, if you're using both Heroku Redis and Redis Enterprise Cloud, set `REDIS_URL_VAR` accordingly:
 
 ```
-heroku config:set REDIS_URL_VAR=REDISCLOUD_URL
+heroku config:set REDIS_URL_VAR=REDIS_URL,REDISCLOUD_URL
 ```
 
 ### Enabling the Datadog Postgres integration
@@ -180,7 +184,11 @@ heroku config:set ENABLE_HEROKU_POSTGRES=true
 
 By default, this integration assumes the Postgres connection URL is defined in an environment variable called `DATABASE_URL` (this is the default configuration for Heroku Postgres and other Postgres add-ons).
 
-If your connection URL is defined in a different environment variable, set the `POSTGRES_URL_VAR` environment variable to the variable name.
+If your connection URL is defined in a different environment variable, or you want to configure more than 1 Postgres instance, set the `POSTGRES_URL_VAR` environment variable to the comma-separated variable names of your connection strings. For example, if you have 2 Postgres instances and the connection strings are stored in `POSTGRES_URL1` and `POSTGRES_URL2`, set `POSTGRES_URL_VAR` accordingly:
+
+```
+heroku config:set POSTGRES_URL_VAR=POSTGRES_URL1,POSTGRES_URL2
+```
 
 ### Enabling other integrations
 

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -182,20 +182,27 @@ if [ "$ENABLE_HEROKU_POSTGRES" == "true" ]; then
     POSTGRES_URL_VAR="DATABASE_URL"
   fi
 
-  cp "$POSTGRES_CONF/conf.yaml.example" "$POSTGRES_CONF/conf.yaml"
+  IFS=","
 
-  if [ -n "${!POSTGRES_URL_VAR}" ]; then
-    POSTGREGEX='^postgres://([^:]+):([^@]+)@([^:]+):([^/]+)/(.*)$'
-    if [[ ${!POSTGRES_URL_VAR} =~ $POSTGREGEX ]]; then
-      sed -i "s/^  - host:.*/  - host: ${BASH_REMATCH[3]}/" "$POSTGRES_CONF/conf.yaml"
-      sed -i "s/^    username:.*/    username: ${BASH_REMATCH[1]}/" "$POSTGRES_CONF/conf.yaml"
-      sed -i "s/^    # password:.*/    password: ${BASH_REMATCH[2]}/" "$POSTGRES_CONF/conf.yaml"
-      sed -i "s/^    # port:.*/    port: ${BASH_REMATCH[4]}/" "$POSTGRES_CONF/conf.yaml"
-      sed -i "s/^    # dbname:.*/    dbname: ${BASH_REMATCH[5]}/" "$POSTGRES_CONF/conf.yaml"
-      sed -i "s/^    # ssl:.*/    ssl: True/" "$POSTGRES_CONF/conf.yaml"
-      sed -i "s/^    disable_generic_tags:.*/    disable_generic_tags: false/" "$POSTGRES_CONF/conf.yaml"
+  touch "$POSTGRES_CONF/conf.yaml"
+  echo -e "init_config: \ninstances: \n" > "$POSTGRES_CONF/conf.yaml"
+
+  for PG_URL in $POSTGRES_URL_VAR
+  do
+    if [ -n "${!PG_URL}" ]; then
+      POSTGREGEX='^postgres://([^:]+):([^@]+)@([^:]+):([^/]+)/(.*)$'
+      if [[ ${!PG_URL} =~ $POSTGREGEX ]]; then
+        echo -e "  - host: ${BASH_REMATCH[3]}" >>  "$POSTGRES_CONF/conf.yaml"
+        echo -e "    username: ${BASH_REMATCH[1]}" >> "$POSTGRES_CONF/conf.yaml"
+        echo -e "    password: ${BASH_REMATCH[2]}" >> "$POSTGRES_CONF/conf.yaml"
+        echo -e "    port: ${BASH_REMATCH[4]}" >> "$POSTGRES_CONF/conf.yaml"
+        echo -e "    dbname: ${BASH_REMATCH[5]}" >> "$POSTGRES_CONF/conf.yaml"
+        echo -e "    ssl: True" >> "$POSTGRES_CONF/conf.yaml"
+        echo -e "    disable_generic_tags: false" >> "$POSTGRES_CONF/conf.yaml"
+      fi
     fi
-  fi
+  done
+  unset IFS
 fi
 
 # Update the Redis configuration from above using the Heroku application environment variable

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -182,6 +182,7 @@ if [ "$ENABLE_HEROKU_POSTGRES" == "true" ]; then
     POSTGRES_URL_VAR="DATABASE_URL"
   fi
 
+  # Use a comma separator instead of new line
   IFS=","
 
   touch "$POSTGRES_CONF/conf.yaml"
@@ -212,26 +213,34 @@ if [ "$ENABLE_HEROKU_REDIS" == "true" ]; then
     REDIS_URL_VAR="REDIS_URL"
   fi
 
-  cp "$REDIS_CONF/conf.yaml.example" "$REDIS_CONF/conf.yaml"
+  # Use a comma separator instead of new line
+  IFS=","
 
-  if [ -n "${!REDIS_URL_VAR}" ]; then
-    REDISREGEX='^redis(s?)://([^:]*):([^@]+)@([^:]+):([^/]+)/?(.*)$'
-    if [[ ${!REDIS_URL_VAR} =~ $REDISREGEX ]]; then
-      sed -i "s/^  - host:.*/  - host: ${BASH_REMATCH[4]}/" "$REDIS_CONF/conf.yaml"
-      sed -i "s/^    # password:.*/    password: ${BASH_REMATCH[3]}/" "$REDIS_CONF/conf.yaml"
-      sed -i "s/^    port:.*/    port: ${BASH_REMATCH[5]}/" "$REDIS_CONF/conf.yaml"
-      if [[ ! -z ${BASH_REMATCH[1]} ]]; then
-        sed -i "s/^    # ssl:.*/    ssl: True/" "$REDIS_CONF/conf.yaml"
-        sed -i "s/^    # ssl_cert_reqs:.*/    ssl_cert_reqs: 0/" "$REDIS_CONF/conf.yaml"
-      fi
-      if [[ ! -z ${BASH_REMATCH[2]} ]]; then
-        sed -i "s/^    # username:.*/    username: ${BASH_REMATCH[2]}/" "$REDIS_CONF/conf.yaml"
-      fi
-      if [[ ! -z ${BASH_REMATCH[6]} ]]; then
-        sed -i "s/^    # db:.*/    db: ${BASH_REMATCH[6]}/" "$REDIS_CONF/conf.yaml"
+  touch "$REDIS_CONF/conf.yaml"
+  echo -e "init_config: \ninstances: \n" > "$REDIS_CONF/conf.yaml"
+
+  for RD_URL in $REDIS_URL_VAR
+  do
+    if [ -n "${!RD_URL}" ]; then
+      REDISREGEX='^redis(s?)://([^:]*):([^@]+)@([^:]+):([^/]+)/?(.*)$'
+      if [[ ${!RD_URL} =~ $REDISREGEX ]]; then
+        echo -e "  - host: ${BASH_REMATCH[4]}" >> "$REDIS_CONF/conf.yaml"
+        echo -e "    password: ${BASH_REMATCH[3]}" >> "$REDIS_CONF/conf.yaml"
+        echo -e "    port: ${BASH_REMATCH[5]}" >> "$REDIS_CONF/conf.yaml"
+        if [[ ! -z ${BASH_REMATCH[1]} ]]; then
+          echo -e "    ssl: True" >> "$REDIS_CONF/conf.yaml"
+          echo -e "    ssl_cert_reqs: 0" >> "$REDIS_CONF/conf.yaml"
+        fi
+        if [[ ! -z ${BASH_REMATCH[2]} ]]; then
+          echo -e "    username: ${BASH_REMATCH[2]}" >> "$REDIS_CONF/conf.yaml"
+        fi
+        if [[ ! -z ${BASH_REMATCH[6]} ]]; then
+          echo -e "    db: ${BASH_REMATCH[6]}" >> "$REDIS_CONF/conf.yaml"
+        fi
       fi
     fi
-  fi
+  done
+  unset IFS
 fi
 
 # Give applications a chance to modify env vars prior to running.


### PR DESCRIPTION
Right now, Redis/Postgres integration auto-discovery only supports 1 connection URL.

This PR changes this and allows to set comma-separated variables for the connection strings