### PR TITLE
Remove some unneeded files for Heroku

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -183,6 +183,7 @@ dpkg -x "$DEB" "$APT_DIR"
 rm -rf "$APT_DIR"/opt/datadog-agent/sources \
        "$APT_DIR"/opt/datadog-agent/embedded/share/doc \
        "$APT_DIR"/opt/datadog-agent/embedded/share/man \
+       "$APT_DIR"/opt/datadog-agent/embedded/sbin/gstatus \
        "$APT_DIR"/opt/datadog-agent/embedded/.installed_by_pkg.txt \
        "$DEB"
 

--- a/bin/compile
+++ b/bin/compile
@@ -201,12 +201,13 @@ for i in "${DELETE_PACKAGES[@]}"; do
   rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/python*/site-packages/"$i"
 done
 
-# Remove the system-probe binary, only needed for network performance monitoring
-# rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/system-probe"
-# rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/clang-bpf"
-# rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/llc-bpf"
-# rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/libbcc*
-# rm -rf "$APT_DIR"/opt/datadog-agent/embedded/nikos/
+# Remove the system-probe binary and share folder, only needed for npm, security
+rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/system-probe"
+rm -rf "$APT_DIR/opt/datadog-agent/embedded/share/system-probe/"
+rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/clang-bpf"
+rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/llc-bpf"
+rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/libbcc*
+rm -rf "$APT_DIR"/opt/datadog-agent/embedded/nikos/
 
 # Remove static libraries
 rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/*.a

--- a/bin/compile
+++ b/bin/compile
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # bin/compile <build-dir> <cache-dir>
 
-DELETE_PACKAGES=(kubernetes lxml openstack pysnmp_mibs pyVim pyVmomi)
+DELETE_PACKAGES=(kubernetes lxml openstack pysnmp_mibs pyVim pyVmomi cm_client)
 
 # Fail fast
 set -e

--- a/bin/compile
+++ b/bin/compile
@@ -202,11 +202,11 @@ for i in "${DELETE_PACKAGES[@]}"; do
 done
 
 # Remove the system-probe binary, only needed for network performance monitoring
-rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/system-probe"
-rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/clang-bpf"
-rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/llc-bpf"
-rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/libbcc*
-rm -rf "$APT_DIR"/opt/datadog-agent/embedded/nikos/
+# rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/system-probe"
+# rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/clang-bpf"
+# rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/llc-bpf"
+# rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/libbcc*
+# rm -rf "$APT_DIR"/opt/datadog-agent/embedded/nikos/
 
 # Remove static libraries
 rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/*.a


### PR DESCRIPTION
This PR removes a set of files in the Agent that won't be needed in Heroku. This reduces its footprint