### PR TITLE
Avoid promoting backslashes to DD_TAGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.13] - 2023-09-01
+
+### Fixed
+- Avoid promoting backslashes to DD_TAGS.
+
 ## [2.12] - 2023-08-31
 
 ### Added

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -287,8 +287,8 @@ fi
 # Convert comma delimited tags from env vars to yaml
 if [ -n "$DD_TAGS" ]; then
   DD_TAGS_NORMALIZED="$(sed "s/,[ ]\?/\ /g"  <<< "$DD_TAGS")"
-  DD_TAGS_NORMALIZED="$(sed 's/\//\\\//g'  <<< "$DD_TAGS_NORMALIZED")"
   DD_TAGS="$DYNO_TAGS $DD_TAGS_NORMALIZED"
+  DD_TAGS_NORMALIZED_YAML="$(sed 's/\//\\\//g'  <<< "$DD_TAGS_NORMALIZED")"
 else
   DD_TAGS="$DYNO_TAGS"
 fi
@@ -297,9 +297,10 @@ export DD_VERSION="$DD_VERSION"
 export DD_TAGS="$DD_TAGS"
 if [ "$DD_LOG_LEVEL_LOWER" == "debug" ]; then
   echo "[DEBUG] Buildpack normalized tags: $DD_TAGS_NORMALIZED"
+  echo "[DEBUG] Buildpack normalized tags to yaml: $DD_TAGS_NORMALIZED_YAML"
 fi
 
-DD_TAGS_YAML="tags:\n  - $(sed 's/\ /\\n  - /g'  <<< "$DD_TAGS")"
+DD_TAGS_YAML="tags:\n  - $(sed 's/\ /\\n  - /g'  <<< "$DD_TAGS_NORMALIZED_YAML")"
 
 # Inject tags after example tags.
 # Config files for agent versions 6.11 and earlier:

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -73,7 +73,7 @@ done
 # Add tags to the config file
 DYNOHOST="$(hostname )"
 DYNOTYPE=${DYNO%%.*}
-BUILDPACKVERSION="dev"
+BUILDPACKVERSION="2.13"
 DYNO_TAGS="dyno:$DYNO dynotype:$DYNOTYPE buildpackversion:$BUILDPACKVERSION"
 
 # We want always to have the Dyno ID as a host alias to improve correlation


### PR DESCRIPTION
We were promoting some escaping back slashes to `DD_TAGS`, breaking some tags using forward slashes when there was a conflict between `DD_TAGS` and the agent configuration file.

This PR fixes the regression and prepares a new buildpack release.

Fixes #346 