### PR TITLE
[COMM-1614] Release 2.14 with agent 7.48.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.14] - 2023-10-18
+
+### Added
+- Datadog Agent pinned versions are now `7.48.1` and `6.48.1`.
+
 ## [2.13] - 2023-09-01
 
 ### Fixed

--- a/bin/compile
+++ b/bin/compile
@@ -11,8 +11,8 @@ set -o pipefail
 # set -x
 
 # Set agent pinned version
-DD_AGENT_PINNED_VERSION_6="6.48.0-1"
-DD_AGENT_PINNED_VERSION_7="7.48.0-1"
+DD_AGENT_PINNED_VERSION_6="6.48.1-1"
+DD_AGENT_PINNED_VERSION_7="7.48.1-1"
 
 # Parse and derive params
 BUILD_DIR=$1

--- a/bin/compile
+++ b/bin/compile
@@ -11,8 +11,8 @@ set -o pipefail
 # set -x
 
 # Set agent pinned version
-DD_AGENT_PINNED_VERSION_6="6.47.0-1"
-DD_AGENT_PINNED_VERSION_7="7.47.0-1"
+DD_AGENT_PINNED_VERSION_6="6.48.0-1"
+DD_AGENT_PINNED_VERSION_7="7.48.0-1"
 
 # Parse and derive params
 BUILD_DIR=$1

--- a/bin/compile
+++ b/bin/compile
@@ -202,6 +202,13 @@ for i in "${DELETE_PACKAGES[@]}"; do
   rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/python*/site-packages/"$i"
 done
 
+POSTGRES_BINARIES=(postgres psql reindexdb vacuumdb createuser clusterdb createdb dropuser dropdb initdb pg_test_timing pg_archivecleanup pg_config pg_test_fsync pg_controldata pg_isready pg_resetwal pg_ctl pg_receivewal pg_recvlogical pg_rewind pg_waldump pg_dumpall pg_basebackup pg_upgrade pgbench pg_restore pg_dump ecpg)
+
+# Remove Postgres binaries
+for i in "${POSTGRES_BINARIES[@]}"; do
+  rm -rf "$APT_DIR"/opt/datadog-agent/embedded/bin/"$i"
+done
+
 # Remove the system-probe binary and share folder, only needed for npm, security
 rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/system-probe"
 rm -rf "$APT_DIR/opt/datadog-agent/embedded/share/system-probe/"

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -212,7 +212,7 @@ if [ "$DD_ENABLE_HEROKU_POSTGRES" == "true" ]; then
         echo -e "    password: ${BASH_REMATCH[2]}" >> "$POSTGRES_CONF/conf.yaml"
         echo -e "    port: ${BASH_REMATCH[4]}" >> "$POSTGRES_CONF/conf.yaml"
         echo -e "    dbname: ${BASH_REMATCH[5]}" >> "$POSTGRES_CONF/conf.yaml"
-        echo -e "    ssl: True" >> "$POSTGRES_CONF/conf.yaml"
+        echo -e "    ssl: require" >> "$POSTGRES_CONF/conf.yaml"
         echo -e "    disable_generic_tags: false" >> "$POSTGRES_CONF/conf.yaml"
         if [ "$DD_ENABLE_DBM" == "true" ]; then
           echo -e "    dbm: true" >> "$POSTGRES_CONF/conf.yaml"
@@ -260,7 +260,7 @@ if [ "$DD_ENABLE_HEROKU_REDIS" == "true" ]; then
         echo -e "    password: ${BASH_REMATCH[3]}" >> "$REDIS_CONF/conf.yaml"
         echo -e "    port: ${BASH_REMATCH[5]}" >> "$REDIS_CONF/conf.yaml"
         if [[ ! -z ${BASH_REMATCH[1]} ]]; then
-          echo -e "    ssl: True" >> "$REDIS_CONF/conf.yaml"
+          echo -e "    ssl: true" >> "$REDIS_CONF/conf.yaml"
           echo -e "    ssl_cert_reqs: 0" >> "$REDIS_CONF/conf.yaml"
         fi
         if [[ ! -z ${BASH_REMATCH[2]} ]]; then

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -73,7 +73,7 @@ done
 # Add tags to the config file
 DYNOHOST="$(hostname )"
 DYNOTYPE=${DYNO%%.*}
-BUILDPACKVERSION="dev"
+BUILDPACKVERSION="2.14"
 DYNO_TAGS="dyno:$DYNO dynotype:$DYNOTYPE buildpackversion:$BUILDPACKVERSION"
 
 # We want always to have the Dyno ID as a host alias to improve correlation


### PR DESCRIPTION
This PR prepares the buildpack for agents 6.48.1 and 7.48.1

It required some changes in the buildpack itself due to changes in the Agent:

* It removes some unneeded postgres binaries that were included in the release. This has been reported to the Agent teams and will be removed in a future release.
* It changes how it configures the Postgres integration, as the new config validation was failing. This has also been reported, as it may affect other Postgres integration users.