### PR TITLE
Remove broken symlink that breaks Gigalixir buildpack builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.15] - 2023-10-19
+## [2.15] - 2023-10-26
 
 ### Fixed
 - Remove broken symlink that breaks Gigalixir buildpack builds (#350)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.15] - 2023-10-19
+
+### Fixed
+- Remove broken symlink that breaks Gigalixir buildpack builds (#350)
+
 ## [2.14] - 2023-10-18
 
 ### Added

--- a/bin/compile
+++ b/bin/compile
@@ -202,7 +202,7 @@ for i in "${DELETE_PACKAGES[@]}"; do
   rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/python*/site-packages/"$i"
 done
 
-POSTGRES_BINARIES=(postgres psql reindexdb vacuumdb createuser clusterdb createdb dropuser dropdb initdb pg_test_timing pg_archivecleanup pg_config pg_test_fsync pg_controldata pg_isready pg_resetwal pg_ctl pg_receivewal pg_recvlogical pg_rewind pg_waldump pg_dumpall pg_basebackup pg_upgrade pgbench pg_restore pg_dump ecpg)
+POSTGRES_BINARIES=(postgres postmaster psql reindexdb vacuumdb createuser clusterdb createdb dropuser dropdb initdb pg_test_timing pg_archivecleanup pg_config pg_test_fsync pg_controldata pg_isready pg_resetwal pg_ctl pg_receivewal pg_recvlogical pg_rewind pg_waldump pg_dumpall pg_basebackup pg_upgrade pgbench pg_restore pg_dump ecpg)
 
 # Remove Postgres binaries
 for i in "${POSTGRES_BINARIES[@]}"; do

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -73,7 +73,7 @@ done
 # Add tags to the config file
 DYNOHOST="$(hostname )"
 DYNOTYPE=${DYNO%%.*}
-BUILDPACKVERSION="dev"
+BUILDPACKVERSION="2.15"
 DYNO_TAGS="dyno:$DYNO dynotype:$DYNOTYPE buildpackversion:$BUILDPACKVERSION"
 
 # We want always to have the Dyno ID as a host alias to improve correlation


### PR DESCRIPTION
When using the Datadog buildpack with Gigalixir buildpack, the latter complains about a broken symlink.
This only happens if the Datadog buildpack is the one removing the files (and breaking the symlink), but not for any other potential broken symlinks that may be part of the Agent.

This PR removes the symlink, part of Postgres, that caused this regression and releases a new version of the buildpack.

Fixes #350