### PR TITLE
Pin versions 7.50 and release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.17] - 2023-12-20
+
+### Added
+- Datadog Agent pinned versions are now `7.50.0` and `6.50.0`.
+
 ## [2.16] - 2023-11-08
 
 ### Added

--- a/bin/compile
+++ b/bin/compile
@@ -11,8 +11,8 @@ set -o pipefail
 # set -x
 
 # Set agent pinned version
-DD_AGENT_PINNED_VERSION_6="6.49.0-1"
-DD_AGENT_PINNED_VERSION_7="7.49.0-1"
+DD_AGENT_PINNED_VERSION_6="6.50.0-1"
+DD_AGENT_PINNED_VERSION_7="7.50.0-1"
 
 # Parse and derive params
 BUILD_DIR=$1

--- a/bin/compile
+++ b/bin/compile
@@ -202,13 +202,6 @@ for i in "${DELETE_PACKAGES[@]}"; do
   rm -rf "$APT_DIR"/opt/datadog-agent/embedded/lib/python*/site-packages/"$i"
 done
 
-POSTGRES_BINARIES=(postgres postmaster psql reindexdb vacuumdb createuser clusterdb createdb dropuser dropdb initdb pg_test_timing pg_archivecleanup pg_config pg_test_fsync pg_controldata pg_isready pg_resetwal pg_ctl pg_receivewal pg_recvlogical pg_rewind pg_waldump pg_dumpall pg_basebackup pg_upgrade pgbench pg_restore pg_dump ecpg)
-
-# Remove Postgres binaries
-for i in "${POSTGRES_BINARIES[@]}"; do
-  rm -rf "$APT_DIR"/opt/datadog-agent/embedded/bin/"$i"
-done
-
 # Remove the system-probe binary and share folder, only needed for npm, security
 rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/system-probe"
 rm -rf "$APT_DIR/opt/datadog-agent/embedded/share/system-probe/"

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -73,7 +73,7 @@ done
 # Add tags to the config file
 DYNOHOST="$(hostname )"
 DYNOTYPE=${DYNO%%.*}
-BUILDPACKVERSION="dev"
+BUILDPACKVERSION="2.17"
 DYNO_TAGS="dyno:$DYNO dynotype:$DYNOTYPE buildpackversion:$BUILDPACKVERSION"
 
 # We want always to have the Dyno ID as a host alias to improve correlation


### PR DESCRIPTION
This PR prepares the buildpack for release with pinned Agent versions 7.50.0 and 6.50.0

It also removes removing the postgres binaries at buildpack level, as those are already removed at the Agent level starting with versions 7/6.50.0