### PR TITLE
[COMM-1856] Fix broken symlinks 

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -258,6 +258,10 @@ if [ "$DD_PYTHON_VERSION" = "3" ]; then
   rm -f "$APT_DIR"/opt/datadog-agent/embedded/bin/pydoc* || true
 fi
 
+# Remove broken symlinks
+rm -f "$APT_DIR"/opt/datadog-agent/embedded/bin/2to3 || true
+rm -f "$APT_DIR"/opt/datadog-agent/embedded/bin/pip || true
+rm -f "$APT_DIR"/opt/datadog-agent/embedded/ssl/cert.pem || true
 
 # Rewrite package-config files
 find "$APT_DIR" -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$APT_DIR"'\1!g'

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -153,7 +153,6 @@ if [ "$DD_PYTHON_VERSION" = "3" ]; then
     ln -sfn "$DD_DIR"/embedded/bin/python3 "$DD_DIR"/embedded/bin/python
     ln -sfn "$DD_DIR"/embedded/bin/python3-config "$DD_DIR"/embedded/bin/python-config
     ln -sfn "$DD_DIR"/embedded/bin/pip3 "$DD_DIR"/embedded/bin/pip
-    ln -sfn "$DD_DIR"/embedded/bin/pydoc3 "$DD_DIR"/embedded/bin/pydoc
 fi
 
 # Ensure all check and library locations are findable in the Python path.

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -155,6 +155,12 @@ if [ "$DD_PYTHON_VERSION" = "3" ]; then
     ln -sfn "$DD_DIR"/embedded/bin/pip3 "$DD_DIR"/embedded/bin/pip
 fi
 
+# Restore symlinks
+if [ "$DD_PYTHON_VERSION" = "2" ]; then
+  ln -sfn "$DD_DIR"/embedded/bin/pip2 "$DD_DIR"/embedded/bin/pip
+fi
+ln -sfn "$DD_DIR"/embedded/ssl/certs/cacert.pem "$DD_DIR"/embedded/ssl/cert.pem
+
 # Ensure all check and library locations are findable in the Python path.
 DD_PYTHONPATH="$DD_DIR/embedded/lib/$PYTHON_DIR"
 DD_PYTHONPATH="$DD_PYTHONPATH:$DD_DIR/embedded/lib/$PYTHON_DIR/site-packages"


### PR DESCRIPTION
This PR fixes remaining broken symlinks, to avoid clashes with buildpacks that use tar following symlinks (i.e. the Gigalixir buildpack)