### PR TITLE
Improve buildpack unit tests

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,4 @@
+tests: .buildpack-testrunner/bin/run .
+tests-with-caching: .buildpack-testrunner/bin/run -c .
+nightly: .buildpack-testrunner/bin/run -s run_nightly_test.sh .
+five: .buildpack-testrunner/bin/run -s run_latest_five_test.sh .

--- a/test/common.sh
+++ b/test/common.sh
@@ -12,10 +12,10 @@ getAvailableVersions()
   APT_REPO_FILE="${BUILDPACK_HOME}/etc/${1}"
   APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR -o Dir::Etc::SourceList=$APT_REPO_FILE"
   apt-get $APT_OPTIONS update
-  if $2; then
-    AGENT_VERSIONS=$(apt-cache $APT_OPTIONS show datadog-agent | grep "Version: " | sed 's/Version: 1://g' | head -n$2)
-  else
+  if [ -z "$2" ]; then
     AGENT_VERSIONS=$(apt-cache $APT_OPTIONS show datadog-agent | grep "Version: " | sed 's/Version: 1://g')
+  else
+    AGENT_VERSIONS=$(apt-cache $APT_OPTIONS show datadog-agent | grep "Version: " | sed 's/Version: 1://g' | head -n$2)
   fi
 }
 

--- a/test/common.sh
+++ b/test/common.sh
@@ -49,9 +49,9 @@ compileAndRunVersion()
   SIZE_EMB_BIN=$(du -s  $HOME/.apt/opt/datadog-agent/embedded/bin | cut -f1)
 
   if $2; then
-    assertTrue "Binary folder is too big: ${SIZE_BIN}" "[ $SIZE_BIN -lt 80000 ]"
-    assertTrue "Embedded library folder is too big: ${SIZE_LIB}" "[ $SIZE_LIB -lt 180000 ]"
-    assertTrue "Embedded binary folder is too big: ${SIZE_EMB_BIN}" "[ $SIZE_EMB_BIN -lt 80000 ]"
+    assertTrue "Binary folder is too big: ${SIZE_BIN}" "[ $SIZE_BIN -lt 85000 ]"
+    assertTrue "Embedded library folder is too big: ${SIZE_LIB}" "[ $SIZE_LIB -lt 220000 ]"
+    assertTrue "Embedded binary folder is too big: ${SIZE_EMB_BIN}" "[ $SIZE_EMB_BIN -lt 100000 ]"
   fi
 
   BROKEN_SYMLINKS=$(find $HOME/.apt/opt/datadog-agent -type l -exec test ! -e {} \; -print | wc -l)

--- a/test/run_all_test.sh
+++ b/test/run_all_test.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+. ./common.sh
+
+export DD_LOG_LEVEL="debug"
+
+testReleased6Versions()
+{
+  echo "deb [trusted=yes] https://apt.datadoghq.com/ stable 6" > "${BUILDPACK_HOME}/etc/datadog.list"
+  getAvailableVersions "datadog.list"
+  echo "deb [signed-by=SIGNED_BY_PLACEHOLDER] https://apt.datadoghq.com/ stable 6" > "${BUILDPACK_HOME}/etc/datadog.list"
+
+  for VERSION in ${AGENT_VERSIONS}; do
+    # Only test for size from 6.34 onwards
+    if test "6.34.0-1" = "$(echo "6.34.0-1\n$VERSION" | sort -V | head -n1)" ; then
+      compileAndRunVersion $VERSION true
+    else
+      compileAndRunVersion $VERSION false
+    fi
+  done
+}
+
+testReleased7Versions()
+{
+  echo "deb [trusted=yes] https://apt.datadoghq.com/ stable 7" > "${BUILDPACK_HOME}/etc/datadog7.list"
+  getAvailableVersions "datadog7.list"
+  echo "deb [signed-by=SIGNED_BY_PLACEHOLDER] https://apt.datadoghq.com/ stable 7" > "${BUILDPACK_HOME}/etc/datadog7.list"
+
+  for VERSION in ${AGENT_VERSIONS}; do
+    # Only test for size from 7.34 onwards
+    if test "7.34.0-1" = "$(echo "7.34.0-1\n$VERSION" | sort -V | head -n1)" ; then
+      compileAndRunVersion $VERSION true
+    else
+      compileAndRunVersion $VERSION false
+    fi
+  done
+}
+
+testLatest6NightlyVersion()
+{
+  echo "deb [trusted=yes] http://apt.datad0g.com/ nightly 6" > "${BUILDPACK_HOME}/etc/datadog.list"
+  getAvailableVersions "datadog.list"
+  VERSION="$(echo ${AGENT_VERSIONS} | head -n1 | awk '{print $1;}')"
+
+  compileAndRunVersion $VERSION
+}
+
+testLatest7NightlyVersion()
+{
+  echo "deb [trusted=yes] http://apt.datad0g.com/ nightly 7" > "${BUILDPACK_HOME}/etc/datadog7.list"
+  getAvailableVersions "datadog7.list"
+  VERSION="$(echo ${AGENT_VERSIONS} | head -n1 | awk '{print $1;}')"
+
+  compileAndRunVersion $VERSION
+}

--- a/test/run_all_test.sh
+++ b/test/run_all_test.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-. ./common.sh
-
 export DD_LOG_LEVEL="debug"
 
 testReleased6Versions()

--- a/test/run_all_test.sh
+++ b/test/run_all_test.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+. ${BUILDPACK_HOME}/test/common.sh
+
 export DD_LOG_LEVEL="debug"
 
 testReleased6Versions()

--- a/test/run_latest_five_test.sh
+++ b/test/run_latest_five_test.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+. ./common.sh
+
+export DD_LOG_LEVEL="debug"
+
+testReleased6Versions()
+{
+  echo "deb [trusted=yes] https://apt.datadoghq.com/ stable 6" > "${BUILDPACK_HOME}/etc/datadog.list"
+  getAvailableVersions "datadog.list"
+  echo "deb [signed-by=SIGNED_BY_PLACEHOLDER] https://apt.datadoghq.com/ stable 6" > "${BUILDPACK_HOME}/etc/datadog.list"
+
+  for VERSION in ${AGENT_VERSIONS}; do
+    # Only test for size from 6.34 onwards
+    if test "6.34.0-1" = "$(echo "6.34.0-1\n$VERSION" | sort -V | head -n1)" ; then
+      compileAndRunVersion $VERSION true
+    else
+      compileAndRunVersion $VERSION false
+    fi
+  done
+}
+
+testReleased7Versions()
+{
+  echo "deb [trusted=yes] https://apt.datadoghq.com/ stable 7" > "${BUILDPACK_HOME}/etc/datadog7.list"
+  getAvailableVersions "datadog7.list"
+  echo "deb [signed-by=SIGNED_BY_PLACEHOLDER] https://apt.datadoghq.com/ stable 7" > "${BUILDPACK_HOME}/etc/datadog7.list"
+
+  for VERSION in ${AGENT_VERSIONS}; do
+    # Only test for size from 7.34 onwards
+    if test "7.34.0-1" = "$(echo "7.34.0-1\n$VERSION" | sort -V | head -n1)" ; then
+      compileAndRunVersion $VERSION true
+    else
+      compileAndRunVersion $VERSION false
+    fi
+  done
+}
+
+testLatest6NightlyVersion()
+{
+  echo "deb [trusted=yes] http://apt.datad0g.com/ nightly 6" > "${BUILDPACK_HOME}/etc/datadog.list"
+  getAvailableVersions "datadog.list"
+  VERSION="$(echo ${AGENT_VERSIONS} | head -n1 | awk '{print $1;}')"
+
+  compileAndRunVersion $VERSION
+}
+
+testLatest7NightlyVersion()
+{
+  echo "deb [trusted=yes] http://apt.datad0g.com/ nightly 7" > "${BUILDPACK_HOME}/etc/datadog7.list"
+  getAvailableVersions "datadog7.list"
+  VERSION="$(echo ${AGENT_VERSIONS} | head -n1 | awk '{print $1;}')"
+
+  compileAndRunVersion $VERSION
+}

--- a/test/run_latest_five_test.sh
+++ b/test/run_latest_five_test.sh
@@ -7,7 +7,7 @@ export DD_LOG_LEVEL="debug"
 testReleased6Versions()
 {
   echo "deb [trusted=yes] https://apt.datadoghq.com/ stable 6" > "${BUILDPACK_HOME}/etc/datadog.list"
-  getAvailableVersions "datadog.list"
+  getAvailableVersions "datadog.list" 5
   echo "deb [signed-by=SIGNED_BY_PLACEHOLDER] https://apt.datadoghq.com/ stable 6" > "${BUILDPACK_HOME}/etc/datadog.list"
 
   for VERSION in ${AGENT_VERSIONS}; do
@@ -23,7 +23,7 @@ testReleased6Versions()
 testReleased7Versions()
 {
   echo "deb [trusted=yes] https://apt.datadoghq.com/ stable 7" > "${BUILDPACK_HOME}/etc/datadog7.list"
-  getAvailableVersions "datadog7.list"
+  getAvailableVersions "datadog7.list" 5
   echo "deb [signed-by=SIGNED_BY_PLACEHOLDER] https://apt.datadoghq.com/ stable 7" > "${BUILDPACK_HOME}/etc/datadog7.list"
 
   for VERSION in ${AGENT_VERSIONS}; do
@@ -36,20 +36,3 @@ testReleased7Versions()
   done
 }
 
-testLatest6NightlyVersion()
-{
-  echo "deb [trusted=yes] http://apt.datad0g.com/ nightly 6" > "${BUILDPACK_HOME}/etc/datadog.list"
-  getAvailableVersions "datadog.list"
-  VERSION="$(echo ${AGENT_VERSIONS} | head -n1 | awk '{print $1;}')"
-
-  compileAndRunVersion $VERSION
-}
-
-testLatest7NightlyVersion()
-{
-  echo "deb [trusted=yes] http://apt.datad0g.com/ nightly 7" > "${BUILDPACK_HOME}/etc/datadog7.list"
-  getAvailableVersions "datadog7.list"
-  VERSION="$(echo ${AGENT_VERSIONS} | head -n1 | awk '{print $1;}')"
-
-  compileAndRunVersion $VERSION
-}

--- a/test/run_latest_five_test.sh
+++ b/test/run_latest_five_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-. ./common.sh
+. ${BUILDPACK_HOME}/test/common.sh
 
 export DD_LOG_LEVEL="debug"
 

--- a/test/run_nightly_test.sh
+++ b/test/run_nightly_test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+. ./common.sh
+
+export DD_LOG_LEVEL="debug"
+
+testLatest6NightlyVersion()
+{
+  echo "deb [trusted=yes] http://apt.datad0g.com/ nightly 6" > "${BUILDPACK_HOME}/etc/datadog.list"
+  getAvailableVersions "datadog.list"
+  VERSION="$(echo ${AGENT_VERSIONS} | head -n1 | awk '{print $1;}')"
+
+  compileAndRunVersion $VERSION
+}
+
+testLatest7NightlyVersion()
+{
+  echo "deb [trusted=yes] http://apt.datad0g.com/ nightly 7" > "${BUILDPACK_HOME}/etc/datadog7.list"
+  getAvailableVersions "datadog7.list"
+  VERSION="$(echo ${AGENT_VERSIONS} | head -n1 | awk '{print $1;}')"
+
+  compileAndRunVersion $VERSION
+}

--- a/test/run_nightly_test.sh
+++ b/test/run_nightly_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-. ./common.sh
+. ${BUILDPACK_HOME}/test/common.sh
 
 export DD_LOG_LEVEL="debug"
 


### PR DESCRIPTION
This PR improves the unit tests for the buildpack, so they are easier to run, and we don't have to run them against every single agent version.

In particular:
* It adds 3 suites: all agent versions, latest 5 released agent versions, and latest nightly build
* It adjust the sizes check to the newer versions of the Agent