### PR TITLE
Pin Agent 6/7.53.0 and prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [2.20] - 2024-05-01
+
+### Added
+- Datadog Agent pinned versions are now `7.53.0` and `6.53.0`.
+
 ## [2.19] - 2024-04-01
 
 ### Added

--- a/bin/compile
+++ b/bin/compile
@@ -11,8 +11,8 @@ set -o pipefail
 # set -x
 
 # Set agent pinned version
-DD_AGENT_PINNED_VERSION_6="6.52.0-1"
-DD_AGENT_PINNED_VERSION_7="7.52.0-1"
+DD_AGENT_PINNED_VERSION_6="6.53.0-1"
+DD_AGENT_PINNED_VERSION_7="7.53.0-1"
 
 # Parse and derive params
 BUILD_DIR=$1

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -77,7 +77,7 @@ done
 # Add tags to the config file
 DYNOHOST="$(hostname )"
 DYNOTYPE=${DYNO%%.*}
-BUILDPACKVERSION="dev"
+BUILDPACKVERSION="2.20"
 DYNO_TAGS="dyno:$DYNO dynotype:$DYNOTYPE buildpackversion:$BUILDPACKVERSION"
 
 # We want always to have the Dyno ID as a host alias to improve correlation


### PR DESCRIPTION
This PR pins the new versions of the Datadog Agent and prepares the buildpack release.