### PR TITLE
[COMM-445] Only use DD_TAGS for tagging

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -315,7 +315,7 @@ fi
 export DD_VERSION="$DD_VERSION"
 export DD_TAGS="$DD_TAGS"
 if [ "$DD_LOG_LEVEL_LOWER" == "debug" ]; then
-  echo "[DEBUG] Buildpack normalized tags: $DD_TAGS_NORMALIZED"
+  echo "[DEBUG] Buildpack normalized tags: $DD_TAGS"
 fi
 
 # Export host type as dyno

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -90,13 +90,6 @@ if [ -n "$HEROKU_APP_NAME" ]; then
   DYNO_TAGS="$DYNO_TAGS appname:$HEROKU_APP_NAME"
 fi
 
-if [ -n "DD_SERVICE" ]; then
-  DYNO_TAGS="$DYNO_TAGS service:$DD_SERVICE"
-fi
-
-if [ -n "DD_VERSION" ]; then
-  DYNO_TAGS="$DYNO_TAGS version:$DD_VERSION"
-fi
 # Uncomment APM configs and add the log file location.
 sed -i -e"s|^# apm_config:$|apm_config:|" "$DATADOG_CONF"
 # Add the log file location.

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -90,6 +90,13 @@ if [ -n "$HEROKU_APP_NAME" ]; then
   DYNO_TAGS="$DYNO_TAGS appname:$HEROKU_APP_NAME"
 fi
 
+if [ -n "DD_SERVICE" ]; then
+  DYNO_TAGS="$DYNO_TAGS service:$DD_SERVICE"
+fi
+
+if [ -n "DD_VERSION" ]; then
+  DYNO_TAGS="$DYNO_TAGS version:$DD_VERSION"
+fi
 # Uncomment APM configs and add the log file location.
 sed -i -e"s|^# apm_config:$|apm_config:|" "$DATADOG_CONF"
 # Add the log file location.

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -301,7 +301,6 @@ fi
 if [ -n "$DD_TAGS" ]; then
   DD_TAGS_NORMALIZED="$(sed "s/,[ ]\?/\ /g"  <<< "$DD_TAGS")"
   DD_TAGS="$DYNO_TAGS $DD_TAGS_NORMALIZED"
-  DD_TAGS_NORMALIZED_YAML="$(sed 's/\//\\\//g'  <<< "$DD_TAGS_NORMALIZED")"
 else
   DD_TAGS="$DYNO_TAGS"
 fi
@@ -312,14 +311,6 @@ if [ "$DD_LOG_LEVEL_LOWER" == "debug" ]; then
   echo "[DEBUG] Buildpack normalized tags: $DD_TAGS_NORMALIZED"
   echo "[DEBUG] Buildpack normalized tags to yaml: $DD_TAGS_NORMALIZED_YAML"
 fi
-
-DD_TAGS_YAML="tags:\n  - $(sed 's/\ /\\n  - /g'  <<< "$DD_TAGS_NORMALIZED_YAML")"
-
-# Inject tags after example tags.
-# Config files for agent versions 6.11 and earlier:
-sed -i "s/^#   - role:database$/#   - role:database\n$DD_TAGS_YAML/" "$DATADOG_CONF"
-# Agent versions 6.12 and later:
-sed -i "s/^\(## @param tags\)/$DD_TAGS_YAML\n\1/" "$DATADOG_CONF"
 
 # Export host type as dyno
 export DD_HEROKU_DYNO="true"

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -309,7 +309,6 @@ export DD_VERSION="$DD_VERSION"
 export DD_TAGS="$DD_TAGS"
 if [ "$DD_LOG_LEVEL_LOWER" == "debug" ]; then
   echo "[DEBUG] Buildpack normalized tags: $DD_TAGS_NORMALIZED"
-  echo "[DEBUG] Buildpack normalized tags to yaml: $DD_TAGS_NORMALIZED_YAML"
 fi
 
 # Export host type as dyno


### PR DESCRIPTION
As DD_TAGS is honoured by the Datadog Agent, there is no need to pass those to the YAML configuration file