### PR TITLE
Avoid deprecated config flags

### DIFF
--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -347,6 +347,19 @@ else
     bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_DIR/embedded/bin/trace-agent -c $DATADOG_CONF 2>&1 &"
   fi
 
+  # From version 7.36 onwards, the config flag for the process agent changed to --cfgpath
+  if [ "$DD_AGENT_MAJOR_VERSION" == "6" ]; then
+    DD_AGENT_BASE_VERSION="6.36.0"
+  else
+    DD_AGENT_BASE_VERSION="7.36.0"
+  fi
+  if version_equal_or_newer $DD_AGENT_VERSION $DD_AGENT_BASE_VERSION; then
+    CONFIG_FLAG="--cfgpath"
+  else
+    CONFIG_FLAG="--config"
+  fi
+
+  # Starting on Agent 7.52.0, the process agent is included in the agent binary
   if [ "$DD_AGENT_MAJOR_VERSION" == "6" ]; then
     DD_AGENT_BASE_VERSION="6.52.0"
   else
@@ -360,9 +373,9 @@ else
     # Starting on Agent 7.52.0, the process agent is included in the agent binary
     if version_equal_or_newer $DD_AGENT_VERSION $DD_AGENT_BASE_VERSION; then
       ln -sfn "$DD_BIN_DIR"/agent "$DD_BIN_DIR"/process-agent
-      bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_BIN_DIR/process-agent --cfgpath $DATADOG_CONF 2>&1 &"
+      bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_BIN_DIR/process-agent $CONFIG_FLAG $DATADOG_CONF 2>&1 &"
     else
-      bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_DIR/embedded/bin/process-agent --cfgpath $DATADOG_CONF 2>&1 &"
+      bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_DIR/embedded/bin/process-agent $CONFIG_FLAG $DATADOG_CONF 2>&1 &"
     fi
   fi
 fi

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -335,6 +335,17 @@ else
   fi
   bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_BIN_DIR/agent $RUN_COMMAND -c $DATADOG_CONF 2>&1 &"
 
+  # From version 7.48 onwards, the config flag for the trace agent changed to --config
+  if [ "$DD_AGENT_MAJOR_VERSION" == "6" ]; then
+    DD_AGENT_BASE_VERSION="6.48.0"
+  else
+    DD_AGENT_BASE_VERSION="7.48.0"
+  fi
+  if version_equal_or_newer $DD_AGENT_VERSION $DD_AGENT_BASE_VERSION; then
+    CONFIG_FLAG="--config"
+  else
+    CONFIG_FLAG="-config"
+  fi
   # The Trace Agent will run by default.
   if [ "$DD_APM_ENABLED" == "false" ]; then
     if [ "$DD_LOG_LEVEL_LOWER" == "debug" ]; then
@@ -344,7 +355,7 @@ else
     if [ "$DD_LOG_LEVEL_LOWER" == "debug" ]; then
       echo "Starting Datadog Trace Agent on $DD_HOSTNAME"
     fi
-    bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_DIR/embedded/bin/trace-agent -c $DATADOG_CONF 2>&1 &"
+    bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_DIR/embedded/bin/trace-agent $CONFIG_FLAG $DATADOG_CONF 2>&1 &"
   fi
 
   # From version 7.36 onwards, the config flag for the process agent changed to --cfgpath

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -344,7 +344,7 @@ else
     if [ "$DD_LOG_LEVEL_LOWER" == "debug" ]; then
       echo "Starting Datadog Trace Agent on $DD_HOSTNAME"
     fi
-    bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_DIR/embedded/bin/trace-agent -config $DATADOG_CONF 2>&1 &"
+    bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_DIR/embedded/bin/trace-agent -c $DATADOG_CONF 2>&1 &"
   fi
 
   if [ "$DD_AGENT_MAJOR_VERSION" == "6" ]; then
@@ -360,9 +360,9 @@ else
     # Starting on Agent 7.52.0, the process agent is included in the agent binary
     if version_equal_or_newer $DD_AGENT_VERSION $DD_AGENT_BASE_VERSION; then
       ln -sfn "$DD_BIN_DIR"/agent "$DD_BIN_DIR"/process-agent
-      bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_BIN_DIR/process-agent -config $DATADOG_CONF 2>&1 &"
+      bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_BIN_DIR/process-agent --cfgpath $DATADOG_CONF 2>&1 &"
     else
-      bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_DIR/embedded/bin/process-agent -config $DATADOG_CONF 2>&1 &"
+      bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_DIR/embedded/bin/process-agent --cfgpath $DATADOG_CONF 2>&1 &"
     fi
   fi
 fi


### PR DESCRIPTION
Since Agent `7.48.0` the `-config` flag for the trace-agent was deprecated in favour of `--config`

Since Agent `7.36.0` the `-config` flag for the `process-agent` was deprecated in favour of `--cfgpath` 

This PR uses the new flags, maintaining backwards compatibility