### PR TITLE
Extract DYNOTYPE from DYNO environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,9 @@ The example below demonstrates a few of the things you can do in the `prerun.sh`
 ```shell
 #!/usr/bin/env bash
 
+# Extract dyno type from Heroku's '$DYNO' environment variable 
+DYNOTYPE="${DYNO%%.*}"
+
 # Disable the Datadog Agent based on dyno type
 if [ "$DYNOTYPE" == "run" ]; then
   DISABLE_DATADOG_AGENT="true"


### PR DESCRIPTION
Not sure if I've misunderstood something, but it turns out that `DYNOTYPE` is not a built-in Heroku environment variable.

This PR updates the documentation to reflect that `DYNOTYPE` needs to be parsed from the `DYNO` (exists in Heroku) variable if needed, rather than being available by default.