### PR TITLE
Improve handling of DYNOTYPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ By default, the Datadog Agent runs on each of the dynos that are part of the app
 To disable the Datadog Agent based on dyno type, add the following snippet to your [prerun.sh script](#prerun-script) (adapting it to the type of dynos you don't want to monitor):
 
 ```shell
+DYNOTYPE=${DYNO%%.*}
 # Disable the Datadog Agent based on dyno type
 if [ "$DYNOTYPE" == "run" ] || [ "$DYNOTYPE" == "scheduler" ] || [ "$DYNOTYPE" == "release" ]; then
   DISABLE_DATADOG_AGENT="true"
@@ -337,7 +338,8 @@ As the filesystem in a Heroku application will be shared by all dynos, if you en
 
 For example, if the Gunicorn integration only needs to run on `web` type dynos, add the following to your prerun script:
 
-```
+```shell
+DYNOTYPE=${DYNO%%.*}
 if [ "$DYNOTYPE" != "web" ]; then
   rm -f "$DD_CONF_DIR/conf.d/gunicorn.d/conf.yaml"
 fi

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -76,7 +76,7 @@ done
 
 # Add tags to the config file
 DYNOHOST="$(hostname )"
-DYNOTYPE=${DYNO%%.*}
+export DYNOTYPE=${DYNO%%.*}
 BUILDPACKVERSION="dev"
 DYNO_TAGS="dyno:$DYNO dynotype:$DYNOTYPE buildpackversion:$BUILDPACKVERSION"
 


### PR DESCRIPTION
`DYNOTYPE` is quite useful, and we recommend it in several places, but we didn't export it before.

This PR exports it going forward, but also updates the docs for users who are in previous version of the buildpack