### PR TITLE
Pin Datadog Agent 7.68.3 

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -12,7 +12,7 @@ set -o pipefail
 
 # Set agent pinned version
 DD_AGENT_PINNED_VERSION_6="6.53.1-1"
-DD_AGENT_PINNED_VERSION_7="7.67.0-1"
+DD_AGENT_PINNED_VERSION_7="7.68.3-1"
 
 # Parse and derive params
 BUILD_DIR=$1

--- a/bin/compile
+++ b/bin/compile
@@ -235,32 +235,41 @@ if [ -f "$ENV_DIR/DD_APM_ENABLED" ]; then
   fi
 fi
 
-if [ "$DD_AGENT_MAJOR_VERSION" == "6" ]; then
-  DD_AGENT_BASE_VERSION="6.52.0"
-else
-  DD_AGENT_BASE_VERSION="7.52.0"
-fi
 
-# If the process agent hasn't been explicitly enabled, delete the agent
-if [ -f "$ENV_DIR/DD_PROCESS_AGENT" ]; then
-  DD_PROCESS_AGENT=$(cat "$ENV_DIR/DD_PROCESS_AGENT")
-  if [ "$DD_PROCESS_AGENT" == "false" ]; then
-    topic "DD_PROCESS_AGENT set to false. Removing the process agent."
-    rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/process-agent"
-    # starting on 7.52.0, there is a binary of core+process agent
-    if version_equal_or_newer $DD_AGENT_VERSION $DD_AGENT_BASE_VERSION; then
-      mv -f "$APT_DIR/opt/datadog-agent/bin/agent/core-agent" "$APT_DIR/opt/datadog-agent/bin/agent/agent" || true
+# Starting with 7.68.0, the core-agent binary is renamed to agent and the process checks are moved to the core agent
+if ! version_equal_or_newer "$DD_AGENT_VERSION" "7.68.0" || [ "$DD_AGENT_MAJOR_VERSION" == "6" ]; then
+  echo "$DD_AGENT_VERSION is not newer than 7.68.0"
+  if [ "$DD_AGENT_MAJOR_VERSION" == "6" ]; then
+    DD_AGENT_BASE_VERSION="6.52.0"
+  else
+    DD_AGENT_BASE_VERSION="7.52.0"
+  fi
+
+  # If the process agent hasn't been explicitly enabled, delete the agent
+  if [ -f "$ENV_DIR/DD_PROCESS_AGENT" ]; then
+    DD_PROCESS_AGENT=$(cat "$ENV_DIR/DD_PROCESS_AGENT")
+    if [ "$DD_PROCESS_AGENT" == "false" ]; then
+      topic "DD_PROCESS_AGENT set to false. Removing the process agent."
+      rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/process-agent"
+      # starting on 7.52.0, there is a binary of core+process agent
+      if version_equal_or_newer $DD_AGENT_VERSION $DD_AGENT_BASE_VERSION; then
+        if [ -f "$APT_DIR/opt/datadog-agent/bin/agent/core-agent" ]; then
+          mv -f "$APT_DIR/opt/datadog-agent/bin/agent/core-agent" "$APT_DIR/opt/datadog-agent/bin/agent/agent" || true
+        fi
+      fi
+    else
+      if version_equal_or_newer $DD_AGENT_VERSION $DD_AGENT_BASE_VERSION; then
+        rm -rf "$APT_DIR/opt/datadog-agent/bin/agent/core-agent" || true
+      fi
     fi
   else
+    topic "DD_PROCESS_AGENT not set. Removing the process agent."
+    rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/process-agent"
     if version_equal_or_newer $DD_AGENT_VERSION $DD_AGENT_BASE_VERSION; then
-      rm -rf "$APT_DIR/opt/datadog-agent/bin/agent/core-agent" || true
+        if [ -f "$APT_DIR/opt/datadog-agent/bin/agent/core-agent" ]; then
+          mv -f "$APT_DIR/opt/datadog-agent/bin/agent/core-agent" "$APT_DIR/opt/datadog-agent/bin/agent/agent" || true
+        fi
     fi
-  fi
-else
-  topic "DD_PROCESS_AGENT not set. Removing the process agent."
-  rm -rf "$APT_DIR/opt/datadog-agent/embedded/bin/process-agent"
-  if version_equal_or_newer $DD_AGENT_VERSION $DD_AGENT_BASE_VERSION; then
-      mv -f "$APT_DIR/opt/datadog-agent/bin/agent/core-agent" "$APT_DIR/opt/datadog-agent/bin/agent/agent" || true
   fi
 fi
 

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -370,23 +370,25 @@ else
     CONFIG_FLAG="--config"
   fi
 
-  # Starting on Agent 7.52.0, the process agent is included in the agent binary
-  if [ "$DD_AGENT_MAJOR_VERSION" == "6" ]; then
-    DD_AGENT_BASE_VERSION="6.52.0"
-  else
-    DD_AGENT_BASE_VERSION="7.52.0"
-  fi
-  # The Process Agent must be run explicitly
-  if [ "$DD_PROCESS_AGENT" == "true" ]; then
-    if [ "$DD_LOG_LEVEL_LOWER" == "debug" ]; then
-      echo "Starting Datadog Process Agent on $DD_HOSTNAME"
-    fi
-    # Starting on Agent 7.52.0, the process agent is included in the agent binary
-    if version_equal_or_newer $DD_AGENT_VERSION $DD_AGENT_BASE_VERSION; then
-      ln -sfn "$DD_BIN_DIR"/agent "$DD_BIN_DIR"/process-agent
-      bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_BIN_DIR/process-agent $CONFIG_FLAG $DATADOG_CONF 2>&1 &"
+  if ! version_equal_or_newer "$DD_AGENT_VERSION" "7.68.0" || [ "$DD_AGENT_MAJOR_VERSION" == "6" ]; then
+    # Starting on Agent 7.52.0, and until 7.68.0, the process agent is included in the agent binary
+    if [ "$DD_AGENT_MAJOR_VERSION" == "6" ]; then
+      DD_AGENT_BASE_VERSION="6.52.0"
     else
-      bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_DIR/embedded/bin/process-agent $CONFIG_FLAG $DATADOG_CONF 2>&1 &"
+      DD_AGENT_BASE_VERSION="7.52.0"
+    fi
+    # The Process Agent must be run explicitly
+    if [ "$DD_PROCESS_AGENT" == "true" ]; then
+      if [ "$DD_LOG_LEVEL_LOWER" == "debug" ]; then
+        echo "Starting Datadog Process Agent on $DD_HOSTNAME"
+      fi
+      # Starting on Agent 7.52.0, the process agent is included in the agent binary
+      if version_equal_or_newer $DD_AGENT_VERSION $DD_AGENT_BASE_VERSION; then
+        ln -sfn "$DD_BIN_DIR"/agent "$DD_BIN_DIR"/process-agent
+        bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_BIN_DIR/process-agent $CONFIG_FLAG $DATADOG_CONF 2>&1 &"
+      else
+        bash -c "PYTHONPATH=\"$DD_PYTHONPATH\" LD_LIBRARY_PATH=\"$DD_LD_LIBRARY_PATH\" $DD_DIR/embedded/bin/process-agent $CONFIG_FLAG $DATADOG_CONF 2>&1 &"
+      fi
     fi
   fi
 fi


### PR DESCRIPTION
A couple of changes here:

- Pinned Agent 7.68.3 (latest)

- Starting on 7.68.3, the process-agent is no longer embedded in the binary called `agent` and `core-agent` no longer exists. Also, the process checks are now part of the core agent (binary `agent`). So, the change here is that if the version is higher than `7.68.0` ignore any code related to removing the `process-agent` or the `core-agent` binaries, and do not start the `process-agent` as it won't exist.  

(explaining this a bit in the description, as the diff generated by Github for Bash is a bit confusing)