### PR TITLE
Bump DD Agent pinned version to 7.79.1-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.41] - 2026-06-04
+## [2.42] - 2026-06-04
 
 ### Added
 - Datadog Agent 7 pinned version is now `7.79.1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.41] - 2026-06-04
+
+### Added
+- Datadog Agent 7 pinned version is now `7.79.1`.
+
 ## [2.41] - 2026-05-21
 
 ### Added

--- a/bin/compile
+++ b/bin/compile
@@ -12,7 +12,7 @@ set -o pipefail
 
 # Set agent pinned version
 DD_AGENT_PINNED_VERSION_6="6.53.1-1"
-DD_AGENT_PINNED_VERSION_7="7.79.0-1"
+DD_AGENT_PINNED_VERSION_7="7.79.1-1"
 
 # Parse and derive params
 BUILD_DIR=$1

--- a/extra/datadog.sh
+++ b/extra/datadog.sh
@@ -74,7 +74,7 @@ done
 # Add tags to the config file
 DYNOHOST="$(hostname )"
 export DYNOTYPE=${DYNO%%.*}
-BUILDPACKVERSION="dev"
+BUILDPACKVERSION="2.42"
 DYNO_TAGS="dyno:$DYNO dynotype:$DYNOTYPE buildpackversion:$BUILDPACKVERSION"
 
 # We want always to have the Dyno ID as a host alias to improve correlation


### PR DESCRIPTION
## What does this PR do?

Bumps the pinned Datadog Agent version 7 from `7.79.0-1` to `7.79.1-1` in `bin/compile`.