### PR TITLE
Update CODEOWNERS to remove advocacy team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,4 @@
 # and another the rest of the directory.
 
 # All your base
-*                   @DataDog/advocacy @DataDog/agent-delivery
+*                   @DataDog/agent-delivery


### PR DESCRIPTION
Removed @DataDog/advocacy from the CODEOWNERS file.