### PR TITLE
Scope apt-get update to the Datadog APT repository

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -136,7 +136,7 @@ sed -i "s|SIGNED_BY_PLACEHOLDER|${DATADOG_APT_KEYRING}|" $APT_REPO_FILE
 
 # Install Datadog Agent
 topic "Updating apt caches for Datadog Agent"
-APT_OPTIONS="$APT_OPTIONS -o Dir::Etc::SourceList=$APT_REPO_FILE"
+APT_OPTIONS="$APT_OPTIONS -o Dir::Etc::SourceList=$APT_REPO_FILE -o Dir::Etc::SourceParts=/dev/null"
 apt-get $APT_OPTIONS update | indent
 
 # Accommodate for earlier pinned versions. Give deprecation warning.

--- a/test/common.sh
+++ b/test/common.sh
@@ -10,7 +10,7 @@ getAvailableVersions()
   mkdir -p "$APT_STATE_DIR/lists/partial"
   mkdir -p "$APT_DIR"
   APT_REPO_FILE="${BUILDPACK_HOME}/etc/${1}"
-  APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR -o Dir::Etc::SourceList=$APT_REPO_FILE"
+  APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR -o Dir::Etc::SourceList=$APT_REPO_FILE -o Dir::Etc::SourceParts=/dev/null"
   apt-get $APT_OPTIONS update
   if [ -z "$2" ]; then
     AGENT_VERSIONS=$(apt-cache $APT_OPTIONS show datadog-agent | grep "Version: " | sed 's/Version: 1://g')


### PR DESCRIPTION
Fixes #443

Adds `-o Dir::Etc::SourceParts=/dev/null` to the `apt-get update` invocation so it reads only the Datadog repository, not the system's `/etc/apt/sources.list.d` entries. Also added the same override in `test/common.sh` so the test helper stays consistent

The buildpack already scopes apt to its own repo by overriding `Dir::Etc::SourceList`. `apt-get update` also reads `Dir::Etc::SourceParts` (`/etc/apt/sources.list.d/`), which the buildpack doesn't override.

This was harmless through Ubuntu 22.04 because OS repos lived in the single `/etc/apt/sources.list`. But Ubuntu 24.04 moved the OS repos into `sources.list.d/ubuntu.sources`. So on Heroku-24/26 the buildpack fetches `archive.ubuntu.com` and `security.ubuntu.com` on every build even though it only installs `datadog-heroku-agent` from `apt.datadoghq.com`.



Verified on `ubuntu:24.04` (apt 2.8.3):

```bash
printf 'deb [trusted=yes] http://apt.datadoghq.example/ stable 7\n' > /tmp/datadog.list

# before (SourceList only): also scans archive/security.ubuntu.com
apt-get -o Dir::Etc::SourceList=/tmp/datadog.list update

# after (this PR): only the Datadog list is read, no warnings
apt-get -o Dir::Etc::SourceList=/tmp/datadog.list -o Dir::Etc::SourceParts=/dev/null update

apt treats the non-directory SourceParts as "no parts" silently — no warning is
emitted. The agent download (apt-get -d install datadog-heroku-agent=...) is
unaffected since it only needs apt.datadoghq.com.
```
